### PR TITLE
Remove upper bound on Mirage

### DIFF
--- a/dns-and-dhcp/config.ml
+++ b/dns-and-dhcp/config.ml
@@ -1,4 +1,4 @@
-(* mirage >= 4.5.0 & < 4.6.0 *)
+(* mirage >= 4.5.0 *)
 
 (* Copyright Robur, 2020 *)
 

--- a/dns-only/config.ml
+++ b/dns-only/config.ml
@@ -1,4 +1,4 @@
-(* mirage >= 4.5.0 & < 4.6.0 *)
+(* mirage >= 4.5.0 *)
 
 (* Copyright Robur, 2020 *)
 


### PR DESCRIPTION
Both unikernels **build** fine with mirage.4.6.1, and for all we know it may as well work with future releases. So I would not add `< 4.7.0`. 