### PR TITLE
Work around default_network --interface argument

### DIFF
--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -31,9 +31,17 @@ let dnsvizor =
   main ~packages "Unikernel.Main"
     (random @-> pclock @-> mclock @-> time @-> network @-> job)
 
+(* this works around the [default_network] on Unix brings a --interface runtime
+   argument that collides with dnsmasq arguments *)
+let mynetwork =
+  match_impl
+    Key.(value target)
+    [ (`Unix, netif ~group:"unix" "tap0") ]
+    ~default:default_network
+
 let () =
   register "dnsvizor"
     [
       dnsvizor $ default_random $ default_posix_clock $ default_monotonic_clock
-      $ default_time $ default_network;
+      $ default_time $ mynetwork;
     ]

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -136,10 +136,7 @@ let dhcp_range =
 let dhcp_range_docv =
   "<start>[,<end>|<mode>[,<netmask>[,<broadcast>]]][,<lease-time>]"
 
-let dhcp_range_c =
-  conv_cmdliner
-    ~docv:dhcp_range_docv
-    dhcp_range pp_dhcp_range
+let dhcp_range_c = conv_cmdliner ~docv:dhcp_range_docv dhcp_range pp_dhcp_range
 
 let parse_file data =
   let rules =


### PR DESCRIPTION
This puts the network device in the "unix" group if we are targeting Unix. This results in the previously duplicate `--interface` argument now being `--unix-interface`.