### PR TITLE
Tweak parser re: white space, comments

### DIFF
--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -28,6 +28,8 @@ let dhcp_range_t =
   in
   Alcotest.testable pp_dhcp_range equal
 
+let parse_one_arg rule input = parse_one (rule arg_end_of_directive) input
+
 let ok_dhcp_range () =
   let input = "192.168.0.50,192.168.0.150,12h" in
   let expected =
@@ -44,7 +46,7 @@ let ok_dhcp_range () =
     check
       (result dhcp_range_t msg_t)
       "DHCP range is good" (Ok expected)
-      (parse_one dhcp_range input))
+      (parse_one_arg dhcp_range input))
 
 let ok_dhcp_range_with_netmask () =
   let input = "192.168.0.50,192.168.0.150,255.255.255.0,12h" in
@@ -62,7 +64,7 @@ let ok_dhcp_range_with_netmask () =
     check
       (result dhcp_range_t msg_t)
       "DHCP range with netmask is good" (Ok expected)
-      (parse_one dhcp_range input))
+      (parse_one_arg dhcp_range input))
 
 let ok_dhcp_range_static () =
   (* NOTE: there's no netmask, with dnsmasq it comes from the configured
@@ -82,7 +84,7 @@ let ok_dhcp_range_static () =
     check
       (result dhcp_range_t msg_t)
       "DHCP range with static is good" (Ok expected)
-      (parse_one dhcp_range input))
+      (parse_one_arg dhcp_range input))
 
 let tests =
   [
@@ -110,7 +112,12 @@ let test_configuration config file () =
         (List.length data)
 
 let config_file_tests =
-  [ ("First example", `Quick, test_configuration [] "simple.conf") ]
+  [
+    ("First example", `Quick, test_configuration [] "simple.conf");
+    ( "White space and comments",
+      `Quick,
+      test_configuration [] "whitespace-and-comments.conf" );
+  ]
 
 let tests =
   [ ("Config tests", tests); ("Configuration file tests", config_file_tests) ]

--- a/test/sample-configuration-files/whitespace-and-comments.conf
+++ b/test/sample-configuration-files/whitespace-and-comments.conf
@@ -1,0 +1,13 @@
+# This is a comment
+listen-address=127.0.0.1,10.8.0.1
+  # this is also a comment with leading whitespace
+    # and configuration directives can also be indented with whitespace
+      bind-interfaces
+# Comments are only allowed on a line by themselves (with optional leading whitespace)
+	bind-interfaces # ok I lied, they can be on directives if there's a space before the '#'
+	bind-interfaces   # and there can be multiple spaces before
+# We can also put spaces after a directive
+bind-interfaces    
+
+# spaces are allowed before and after the equal sign
+     interface     =          br0


### PR DESCRIPTION
Comments can also occur on the same line as a directive iff there's a whitespace in between. Likewise, we can have trailing spaces and spaces before and after the equal sign.