### PR TITLE
Parse --dhcp-host

### DIFF
--- a/dnsvizor.opam
+++ b/dnsvizor.opam
@@ -25,6 +25,7 @@ depends: [
   "ipaddr" {>= "5.6.0"}
   "cmdliner" {>= "1.2.0"}
   "logs" {>= "0.7.0"}
+  "ohex" {>= "0.2.0"}
 
   "alcotest" {with-test & >= "1.8.0"}
 ]

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -243,6 +243,7 @@ let dhcp_host end_of_directive =
            (* FIXME: probably be more precise in accepted characters *)
            ( scan false (fun is_hex -> function
                | ',' -> None | ':' -> Some true | _ -> Some is_hex)
+           <* commit
            >>= fun (name, is_hex) ->
              if is_hex then
                (* This is not very smart *)
@@ -251,7 +252,8 @@ let dhcp_host end_of_directive =
                in
                match Ohex.decode hex_name with
                | name -> return (`Client_id name)
-               | exception Invalid_argument _ -> fail "bad hex constant"
+               | exception Invalid_argument _ ->
+                   fail (Fmt.str "bad hex constant: %S" name)
              else return (`Client_id name) );
          ]
   in

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -266,7 +266,10 @@ let dhcp_host end_of_directive =
        try to parse mac addresses for exotic hardware. We will allow ethernet
        (10 Mb) mac type only. *)
     (* TODO: wildcards *)
-    let ishex = function '0' .. '9' | 'a'..'f' | 'A'..'F' -> true | _ -> false in
+    let ishex = function
+      | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true
+      | _ -> false
+    in
     option "" (string "1-") *> peek_string 3 >>= fun first ->
     if ishex first.[0] && ishex first.[1] && first.[2] = ':' then
       commit *> take ((6 * 2) + 5) >>= fun mac ->

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -256,7 +256,13 @@ let dhcp_host end_of_directive =
          ]
   in
   let net_set_thing =
-    choice [ string "net:"; string "set:" ] *> commit *> until_comma
+    choice
+      [
+        string "net:" *> commit
+        *> fail "Using 'net:' is unsupported; use 'set:' instead.";
+        string "set:";
+      ]
+    *> commit *> until_comma
     >>| fun set -> `Set set
   in
   let tag_thing =

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -252,8 +252,8 @@ let dhcp_host end_of_directive =
                in
                match Ohex.decode hex_name with
                | name -> return (`Client_id name)
-               | exception Invalid_argument _ ->
-                   fail (Fmt.str "bad hex constant: %S" name)
+               | exception Invalid_argument e ->
+                   fail (Fmt.str "bad hex constant: %s: %S" e name)
              else return (`Client_id name) );
          ]
   in

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -94,7 +94,7 @@ type dhcp_range = {
   lease_time : int option;
 }
 
-type dhcp_config = {
+type dhcp_host = {
   id : [ `Any_client_id | `Client_id of string ] option;
   sets : string list;
   tags : string list;
@@ -106,7 +106,7 @@ type dhcp_config = {
   (* TODO: [`host] Domain_name.t?! *)
   domain_name : [ `raw ] Domain_name.t option;
 }
-(* the dhcp_config data structure is not great to work with. The fields [id],
+(* the dhcp_host data structure is not great to work with. The fields [id],
    [sets], [tags] and [macs] are used for matching clients. The fields [ipv4]
    and [lease_time] are values to assign to matching clients. The [ignore]
    field says to ignore matching clients making the [ipv4] and [lease_time]
@@ -138,7 +138,7 @@ let pp_dhcp_range ppf
     Fmt.(option ~none:nop (any "," ++ pp_duration))
     lease_time
 
-let pp_dhcp_config ppf
+let pp_dhcp_host ppf
     { id; sets; tags; macs; ipv4; ipv6; lease_time; ignore; domain_name } =
   let sep =
     let use_sep = ref false in
@@ -393,7 +393,7 @@ let dhcp_host_docv =
 let dhcp_host_c =
   conv_cmdliner ~docv:dhcp_range_docv
     (dhcp_host arg_end_of_directive)
-    pp_dhcp_config
+    pp_dhcp_host
 
 let parse_file data =
   let rules =

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -230,13 +230,26 @@ let dhcp_host end_of_directive =
       tag_thing ;
       mac_addr ;
       ipv4_addr ;
+      (* TODO: ipv6_addr ; *)
       lease_time ;
       ignore_thing ;
       hostname ;
     ]
   in
   sep_by1 (char ',') dhcp_host_item <* end_of_directive >>= fun items ->
-  (* TODO: process items *)
+  (* TODO: process items:
+     - We can have at most one id thing except and id and id:* whose semantics
+       are very unclear. Thus we should probably forbid that combination.
+     - For net:/set: we can have as many as we like.
+     - We can as well have as many tag: as we like.
+     - There is also no limit on mac addresses.
+     - There can be at most one ipv4 address.
+     - There can be at most one lease time.
+     - The ignore thing will set a flag. Repeating it is redundant if harmless.
+     - There can be at most one domain name.
+     The option parser in dnsmasq will not enforce much of this. Instead, the
+     last value will overwrite previous values if only one value makes sense.
+     We should do better.  *)
   ignore items;
   return ()
 

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -265,9 +265,9 @@ let dhcp_host end_of_directive =
        try to parse mac addresses for exotic hardware. We will allow ethernet
        (10 Mb) mac type only. *)
     (* TODO: wildcards *)
-    let isdecimal = function '0' .. '9' -> true | _ -> false in
+    let ishex = function '0' .. '9' | 'a'..'f' | 'A'..'F' -> true | _ -> false in
     option "" (string "1-") *> peek_string 3 >>= fun first ->
-    if isdecimal first.[0] && isdecimal first.[1] && first.[2] = ':' then
+    if ishex first.[0] && ishex first.[1] && first.[2] = ':' then
       commit *> take ((6 * 2) + 5) >>= fun mac ->
       match Macaddr.of_string mac with
       | Ok mac -> return (`Macaddr mac)

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -107,10 +107,11 @@ type dhcp_host = {
   domain_name : [ `raw ] Domain_name.t option;
 }
 (* the dhcp_host data structure is not great to work with. The fields [id],
-   [sets], [tags] and [macs] are used for matching clients. The fields [ipv4]
-   and [lease_time] are values to assign to matching clients. The [ignore]
-   field says to ignore matching clients making the [ipv4] and [lease_time]
-   fields questionable. *)
+   [tags] and [macs] are used for matching clients. The fields [ipv4] and
+   [lease_time] are values to assign to matching clients. The [sets] field is
+   used to internally assign tags to matching clients. The [ignore] field says
+   to ignore matching clients making the [ipv4] and [lease_time] fields
+   questionable. *)
 
 let pp_duration ppf = function
   | x when x = infinite -> Fmt.string ppf "infinite"

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -107,7 +107,7 @@ type dhcp_host = {
   domain_name : [ `raw ] Domain_name.t option;
 }
 (* the dhcp_host data structure is not great to work with. The fields [id],
-   [tags] and [macs] are used for matching clients. The fields [ipv4] and
+   and [macs] are used for matching clients DHCPREQUEST. The [tags] field is matched internally to add more dhcp options in the DHCPREPLY. The fields [ipv4] and
    [lease_time] are values to assign to matching clients. The [sets] field is
    used to internally assign tags to matching clients. The [ignore] field says
    to ignore matching clients making the [ipv4] and [lease_time] fields

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -107,11 +107,12 @@ type dhcp_host = {
   domain_name : [ `raw ] Domain_name.t option;
 }
 (* the dhcp_host data structure is not great to work with. The fields [id],
-   and [macs] are used for matching clients DHCPREQUEST. The [tags] field is matched internally to add more dhcp options in the DHCPREPLY. The fields [ipv4] and
-   [lease_time] are values to assign to matching clients. The [sets] field is
-   used to internally assign tags to matching clients. The [ignore] field says
-   to ignore matching clients making the [ipv4] and [lease_time] fields
-   questionable. *)
+   and [macs] are used for matching clients DHCPREQUEST. The [tags] field is
+   matched internally to add more dhcp options in the DHCPREPLY. The fields
+   [ipv4] and [lease_time] are values to assign to matching clients. The [sets]
+   field is used to internally assign tags to matching clients. The [ignore]
+   field says to ignore matching clients making the [ipv4] and [lease_time]
+   fields questionable. *)
 
 let pp_duration ppf = function
   | x when x = infinite -> Fmt.string ppf "infinite"

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -96,7 +96,7 @@ type dhcp_range = {
 
 type dhcp_config = {
   id : [ `Any_client_id | `Client_id of string ] option;
-  nets : string list;
+  sets : string list;
   tags : string list;
   macs : Macaddr.t list;
   ipv4 : Ipaddr.V4.t option;
@@ -107,7 +107,7 @@ type dhcp_config = {
   domain_name : [ `raw ] Domain_name.t option;
 }
 (* the dhcp_config data structure is not great to work with. The fields [id],
-   [nets], [tags] and [macs] are used for matching clients. The fields [ipv4]
+   [sets], [tags] and [macs] are used for matching clients. The fields [ipv4]
    and [lease_time] are values to assign to matching clients. The [ignore]
    field says to ignore matching clients making the [ipv4] and [lease_time]
    fields questionable. *)
@@ -139,7 +139,7 @@ let pp_dhcp_range ppf
     lease_time
 
 let pp_dhcp_config ppf
-    { id; nets; tags; macs; ipv4; ipv6; lease_time; ignore; domain_name } =
+    { id; sets; tags; macs; ipv4; ipv6; lease_time; ignore; domain_name } =
   let sep =
     let use_sep = ref false in
     fun () ->
@@ -161,10 +161,10 @@ let pp_dhcp_config ppf
           Fmt.pf ppf "id:%s" id)
     id;
   List.iter
-    (fun net ->
+    (fun set ->
       sep ();
-      Fmt.pf ppf "net:%s" net)
-    nets;
+      Fmt.pf ppf "set:%s" set)
+    sets;
   List.iter
     (fun tag ->
       sep ();
@@ -255,7 +255,7 @@ let dhcp_host end_of_directive =
   in
   let net_set_thing =
     choice [ string "net:"; string "set:" ] *> commit *> until_comma
-    >>| fun net -> `Net net
+    >>| fun set -> `Set set
   in
   let tag_thing =
     string "tag:" *> commit *> until_comma >>| fun tag -> `Tag tag
@@ -329,7 +329,7 @@ let dhcp_host end_of_directive =
               Log.warn (fun m ->
                   m "Redundant id in --dhcp-host. Ignoring previous value!");
             { config with id = Some id }
-        | `Net net -> { config with nets = net :: config.nets }
+        | `Set set -> { config with sets = set :: config.sets }
         | `Tag tag -> { config with tags = tag :: config.tags }
         | `Macaddr mac -> { config with macs = mac :: config.macs }
         | `Ipv4addr ipv4 ->
@@ -357,7 +357,7 @@ let dhcp_host end_of_directive =
             { config with domain_name = Some domain_name })
       {
         id = None;
-        nets = [];
+        sets = [];
         tags = [];
         macs = [];
         ipv4 = None;
@@ -372,7 +372,7 @@ let dhcp_host end_of_directive =
   let thing =
     {
       thing with
-      nets = List.rev thing.nets;
+      sets = List.rev thing.sets;
       tags = List.rev thing.tags;
       macs = List.rev thing.macs;
     }

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (name dnsvizor)
  (public_name dnsvizor)
- (libraries angstrom fmt ipaddr cmdliner logs))
+ (libraries angstrom fmt ipaddr cmdliner logs ohex))

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -32,7 +32,7 @@ let dhcp_range_t =
 
 let dhcp_host_t =
   let equal
-      { id; nets; tags; macs; ipv4; ipv6; lease_time; ignore; domain_name } b =
+      { id; sets; tags; macs; ipv4; ipv6; lease_time; ignore; domain_name } b =
     Option.equal
       (fun id id' ->
         match (id, id') with
@@ -40,7 +40,7 @@ let dhcp_host_t =
         | `Client_id id, `Client_id id' -> String.equal id id'
         | `Any_client_id, `Client_id _ | `Client_id _, `Any_client_id -> false)
       id b.id
-    && List.equal String.equal nets b.nets
+    && List.equal String.equal sets b.sets
     && List.equal String.equal tags b.tags
     && List.equal mac_eq macs b.macs
     && Option.equal ipv4_eq ipv4 b.ipv4
@@ -109,9 +109,9 @@ let ok_dhcp_range_static () =
       "DHCP range with static is good" (Ok expected)
       (parse_one_arg dhcp_range input))
 
-let make_dhcp_config ?id ?(nets = []) ?(tags = []) ?(macs = []) ?ipv4 ?ipv6
+let make_dhcp_config ?id ?(sets = []) ?(tags = []) ?(macs = []) ?ipv4 ?ipv6
     ?lease_time ?(ignore = false) ?domain_name () =
-  { id; nets; tags; macs; ipv4; ipv6; lease_time; ignore; domain_name }
+  { id; sets; tags; macs; ipv4; ipv6; lease_time; ignore; domain_name }
 
 let ok_dhcp_host_thedoctor () =
   let input = "00:00:5e:00:53:42,thedoctor,192.168.0.10" in
@@ -245,7 +245,7 @@ let ok_dhcp_host_dnsmasq_conf_example =
         "11:22:33:44:55:66,set:red",
         make_dhcp_config
           ~macs:[ Macaddr.of_string_exn "11:22:33:44:55:66" ]
-          ~nets:[ "red" ] () );
+          ~sets:[ "red" ] () );
       (* TODO:
          ("Thirteenth dhcp-host from dnsmasq.conf.example",
            "11:22:33:*:*:*,set:red",

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -157,10 +157,10 @@ let ok_dhcp_host_sonicscrewdriver () =
     (parse_one_arg dhcp_host input)
 
 let ok_dhcp_host_apollon () =
-  let input = "52:54:00:42:6a:43,apollon,10.10.10.51,infinite" in
+  let input = "a2:54:00:42:6a:43,apollon,10.10.10.51,infinite" in
   let expected =
     make_dhcp_host
-      ~macs:[ Macaddr.of_string_exn "52:54:00:42:6a:43" ]
+      ~macs:[ Macaddr.of_string_exn "a2:54:00:42:6a:43" ]
       ~domain_name:(Domain_name.of_string_exn "apollon")
       ~ipv4:(Ipaddr.V4.of_string_exn "10.10.10.51")
       ~lease_time:(1 lsl 32) (* infinite *)

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -49,7 +49,7 @@ let dhcp_host_t =
     && Bool.equal ignore b.ignore
     && Option.equal Domain_name.equal domain_name b.domain_name
   in
-  Alcotest.testable pp_dhcp_config equal
+  Alcotest.testable pp_dhcp_host equal
 
 let parse_one_arg rule input = parse_one (rule arg_end_of_directive) input
 
@@ -109,14 +109,14 @@ let ok_dhcp_range_static () =
       "DHCP range with static is good" (Ok expected)
       (parse_one_arg dhcp_range input))
 
-let make_dhcp_config ?id ?(sets = []) ?(tags = []) ?(macs = []) ?ipv4 ?ipv6
+let make_dhcp_host ?id ?(sets = []) ?(tags = []) ?(macs = []) ?ipv4 ?ipv6
     ?lease_time ?(ignore = false) ?domain_name () =
   { id; sets; tags; macs; ipv4; ipv6; lease_time; ignore; domain_name }
 
 let ok_dhcp_host_thedoctor () =
   let input = "00:00:5e:00:53:42,thedoctor,192.168.0.10" in
   let expected =
-    make_dhcp_config
+    make_dhcp_host
       ~macs:[ Macaddr.of_string_exn "00:00:5e:00:53:42" ]
       ~domain_name:(Domain_name.of_string_exn "thedoctor")
       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.10")
@@ -129,7 +129,7 @@ let ok_dhcp_host_thedoctor () =
 let ok_dhcp_host_tardis () =
   let input = "00:00:5e:00:53:01,00:00:5e:00:53:02,tardis,192.168.0.22" in
   let expected =
-    make_dhcp_config
+    make_dhcp_host
       ~macs:
         Macaddr.
           [
@@ -146,7 +146,7 @@ let ok_dhcp_host_tardis () =
 let ok_dhcp_host_sonicscrewdriver () =
   let input = "00:00:5e:00:53:08,sonicscrewdriver,192.168.0.23" in
   let expected =
-    make_dhcp_config
+    make_dhcp_host
       ~macs:[ Macaddr.of_string_exn "00:00:5e:00:53:08" ]
       ~domain_name:(Domain_name.of_string_exn "sonicscrewdriver")
       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.23")
@@ -159,7 +159,7 @@ let ok_dhcp_host_sonicscrewdriver () =
 let ok_dhcp_host_apollon () =
   let input = "52:54:00:42:6a:43,apollon,10.10.10.51,infinite" in
   let expected =
-    make_dhcp_config
+    make_dhcp_host
       ~macs:[ Macaddr.of_string_exn "52:54:00:42:6a:43" ]
       ~domain_name:(Domain_name.of_string_exn "apollon")
       ~ipv4:(Ipaddr.V4.of_string_exn "10.10.10.51")
@@ -183,26 +183,26 @@ let ok_dhcp_host_dnsmasq_conf_example =
     [
       ( "First dhcp-host from dnsmasq.conf.example",
         "11:22:33:44:55:66,192.168.0.60",
-        make_dhcp_config
+        make_dhcp_host
           ~macs:[ Macaddr.of_string_exn "11:22:33:44:55:66" ]
           ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60")
           () );
       ( "Second dhcp-host from dnsmasq.conf.example",
         "11:22:33:44:55:66,fred",
-        make_dhcp_config
+        make_dhcp_host
           ~macs:[ Macaddr.of_string_exn "11:22:33:44:55:66" ]
           ~domain_name:(Domain_name.of_string_exn "fred")
           () );
       ( "Third dhcp-host from dnsmasq.conf.example",
         "11:22:33:44:55:66,fred,192.168.0.60,45m",
-        make_dhcp_config
+        make_dhcp_host
           ~macs:[ Macaddr.of_string_exn "11:22:33:44:55:66" ]
           ~domain_name:(Domain_name.of_string_exn "fred")
           ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60")
           ~lease_time:(45 * 60) () );
       ( "Fourth dhcp-host from dnsmasq.conf.example",
         "11:22:33:44:55:66,12:34:56:78:90:12,192.168.0.60",
-        make_dhcp_config
+        make_dhcp_host
           ~macs:
             Macaddr.
               [
@@ -213,37 +213,37 @@ let ok_dhcp_host_dnsmasq_conf_example =
           () );
       ( "Fifth dhcp-host from dnsmasq.conf.example",
         "bert,192.168.0.70,infinite",
-        make_dhcp_config
+        make_dhcp_host
           ~domain_name:(Domain_name.of_string_exn "bert")
           ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.70")
           ~lease_time:(1 lsl 32) () );
       ( "Sixth dhcp-host from dnsmasq.conf.example",
         "id:01:02:02:04,192.168.0.60",
-        make_dhcp_config ~id:(`Client_id "\x01\x02\x02\x04")
+        make_dhcp_host ~id:(`Client_id "\x01\x02\x02\x04")
           ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60")
           () );
       (* skipping seventh as it's similar to above, but is infiniband in a manner we wouldn't care about *)
       ( "Eigth dhcp-host from dnsmasq.conf.example",
         "id:marjorie,192.168.0.60",
-        make_dhcp_config ~id:(`Client_id "marjorie")
+        make_dhcp_host ~id:(`Client_id "marjorie")
           ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60")
           () );
       ( "Ninth dhcp-host from dnsmasq.conf.example",
         "judge",
-        make_dhcp_config ~domain_name:(Domain_name.of_string_exn "judge") () );
+        make_dhcp_host ~domain_name:(Domain_name.of_string_exn "judge") () );
       ( "Tenth dhcp-host from dnsmasq.conf.example",
         "11:22:33:44:55:66,ignore",
-        make_dhcp_config
+        make_dhcp_host
           ~macs:[ Macaddr.of_string_exn "11:22:33:44:55:66" ]
           ~ignore:true () );
       ( "Eleventh dhcp-host from dnsmasq.conf.example",
         "11:22:33:44:55:66,id:*",
-        make_dhcp_config ~id:`Any_client_id
+        make_dhcp_host ~id:`Any_client_id
           ~macs:[ Macaddr.of_string_exn "11:22:33:44:55:66" ]
           () );
       ( "Twelvth dhcp-host from dnsmasq.conf.example",
         "11:22:33:44:55:66,set:red",
-        make_dhcp_config
+        make_dhcp_host
           ~macs:[ Macaddr.of_string_exn "11:22:33:44:55:66" ]
           ~sets:[ "red" ] () );
       (* TODO:

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -10,7 +10,11 @@ let opt_eq f a b =
   | Some a, Some b -> f a b
   | None, Some _ | Some _, None -> false
 
-let ip_eq a b = Ipaddr.V4.compare a b = 0
+let ipv4_eq a b = Ipaddr.V4.compare a b = 0
+
+let ipv6_eq a b = Ipaddr.V6.compare a b = 0
+
+let mac_eq a b = Macaddr.compare a b = 0
 
 let mode_eq a b =
   match (a, b) with
@@ -19,14 +23,33 @@ let mode_eq a b =
 
 let dhcp_range_t =
   let equal a b =
-    ip_eq a.start_addr b.start_addr
-    && opt_eq ip_eq a.end_addr b.end_addr
+    ipv4_eq a.start_addr b.start_addr
+    && opt_eq ipv4_eq a.end_addr b.end_addr
     && opt_eq mode_eq a.mode b.mode
-    && opt_eq ip_eq a.netmask b.netmask
-    && opt_eq ip_eq a.broadcast b.broadcast
+    && opt_eq ipv4_eq a.netmask b.netmask
+    && opt_eq ipv4_eq a.broadcast b.broadcast
     && opt_eq Int.equal a.lease_time b.lease_time
   in
   Alcotest.testable pp_dhcp_range equal
+
+let dhcp_host_t =
+  let equal { id; nets; tags; macs; ipv4; ipv6; lease_time; ignore; domain_name } b =
+    Option.equal (fun id id' ->
+        match id, id' with
+        | `Any_client_id, `Any_client_id -> true
+        | `Client_id id, `Client_id id' -> String.equal id id'
+        | `Any_client_id, `Client_id _ | `Client_id _, `Any_client_id -> false)
+      id b.id &&
+    List.equal String.equal nets b.nets &&
+    List.equal String.equal tags b.tags &&
+    List.equal mac_eq macs b.macs &&
+    Option.equal ipv4_eq ipv4 b.ipv4 &&
+    Option.equal ipv6_eq ipv6 b.ipv6 &&
+    Option.equal Int.equal lease_time b.lease_time &&
+    Bool.equal ignore b.ignore &&
+    Option.equal Domain_name.equal domain_name b.domain_name
+  in
+  Alcotest.testable pp_dhcp_config equal
 
 let parse_one_arg rule input = parse_one (rule arg_end_of_directive) input
 
@@ -86,12 +109,138 @@ let ok_dhcp_range_static () =
       "DHCP range with static is good" (Ok expected)
       (parse_one_arg dhcp_range input))
 
+let make_dhcp_config ?id ?(nets=[]) ?(tags=[]) ?(macs=[]) ?ipv4 ?ipv6 ?lease_time ?(ignore=false) ?domain_name () =
+  { id; nets; tags; macs; ipv4; ipv6; lease_time; ignore; domain_name }
+
+let ok_dhcp_host_thedoctor () =
+  let input = "00:00:5e:00:53:42,thedoctor,192.168.0.10" in
+  let expected =
+    make_dhcp_config
+      ~macs:[Macaddr.of_string_exn "00:00:5e:00:53:42"]
+      ~domain_name:(Domain_name.of_string_exn "thedoctor")
+      ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.10")
+      ()
+  in
+  Alcotest.(check (result dhcp_host_t msg_t)) "DHCP host thedoctor is good"
+    (Ok expected) (parse_one_arg dhcp_host input)
+
+let ok_dhcp_host_tardis () =
+  let input = "00:00:5e:00:53:01,00:00:5e:00:53:02,tardis,192.168.0.22" in
+  let expected =
+    make_dhcp_config
+      ~macs:Macaddr.[of_string_exn "00:00:5e:00:53:01";
+                     of_string_exn "00:00:5e:00:53:02"]
+      ~domain_name:(Domain_name.of_string_exn "tardis")
+      ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.22")
+      ()
+  in
+  Alcotest.(check (result dhcp_host_t msg_t)) "DHCP host tardis is good"
+    (Ok expected) (parse_one_arg dhcp_host input)
+
+let ok_dhcp_host_sonicscrewdriver () =
+  let input = "00:00:5e:00:53:08,sonicscrewdriver,192.168.0.23" in
+  let expected =
+    make_dhcp_config
+      ~macs:[Macaddr.of_string_exn "00:00:5e:00:53:08"]
+      ~domain_name:(Domain_name.of_string_exn "sonicscrewdriver")
+      ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.23")
+      ()
+  in
+  Alcotest.(check (result dhcp_host_t msg_t)) "DHCP host sonicscrewdriver is good"
+    (Ok expected) (parse_one_arg dhcp_host input)
+
+let ok_dhcp_host_apollon () =
+  let input = "52:54:00:42:6a:43,apollon,10.10.10.51,infinite" in
+  let expected =
+    make_dhcp_config
+      ~macs:[Macaddr.of_string_exn "52:54:00:42:6a:43"]
+      ~domain_name:(Domain_name.of_string_exn "apollon")
+      ~ipv4:(Ipaddr.V4.of_string_exn "10.10.10.51")
+      ~lease_time:(1 lsl 32) (* infinite *)
+      ()
+  in
+  Alcotest.(check (result dhcp_host_t msg_t)) "DHCP host apollon is good"
+    (Ok expected) (parse_one_arg dhcp_host input)
+
+let ok_dhcp_host_dnsmasq_conf_example =
+  let to_test (name, input, expected) =
+    (name, `Quick, fun () ->
+        Alcotest.(check (result dhcp_host_t msg_t))
+          (name ^ " is good")
+          (Ok expected)
+          (parse_one_arg dhcp_host input))
+  in
+  List.map to_test [
+    ("First dhcp-host from dnsmasq.conf.example",
+     "11:22:33:44:55:66,192.168.0.60",
+     make_dhcp_config ~macs:[Macaddr.of_string_exn "11:22:33:44:55:66"]
+       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60") ());
+    ("Second dhcp-host from dnsmasq.conf.example",
+     "11:22:33:44:55:66,fred",
+     make_dhcp_config ~macs:[Macaddr.of_string_exn "11:22:33:44:55:66"]
+       ~domain_name:(Domain_name.of_string_exn "fred") ());
+    ("Third dhcp-host from dnsmasq.conf.example",
+     "11:22:33:44:55:66,fred,192.168.0.60,45m",
+     make_dhcp_config ~macs:[Macaddr.of_string_exn "11:22:33:44:55:66"]
+       ~domain_name:(Domain_name.of_string_exn "fred")
+       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60")
+       ~lease_time:(45*60) ());
+    ("Fourth dhcp-host from dnsmasq.conf.example",
+     "11:22:33:44:55:66,12:34:56:78:90:12,192.168.0.60",
+     make_dhcp_config ~macs:Macaddr.[of_string_exn "11:22:33:44:55:66";
+                                     of_string_exn "12:34:56:78:90:12"]
+       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60") ());
+    ("Fifth dhcp-host from dnsmasq.conf.example",
+     "bert,192.168.0.70,infinite",
+     make_dhcp_config ~domain_name:(Domain_name.of_string_exn "bert")
+       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.70")
+       ~lease_time:(1 lsl 32) ());
+    ("Sixth dhcp-host from dnsmasq.conf.example",
+     "id:01:02:02:04,192.168.0.60",
+     make_dhcp_config ~id:(`Client_id "\x01\x02\x02\x04")
+       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60") ());
+    (* skipping seventh as it's similar to above, but is infiniband in a manner we wouldn't care about *)
+    ("Eigth dhcp-host from dnsmasq.conf.example",
+     "id:marjorie,192.168.0.60",
+     make_dhcp_config ~id:(`Client_id "marjorie")
+       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60") ());
+    ("Ninth dhcp-host from dnsmasq.conf.example",
+     "judge",
+     make_dhcp_config ~domain_name:(Domain_name.of_string_exn "judge")
+       ());
+    ("Tenth dhcp-host from dnsmasq.conf.example",
+     "11:22:33:44:55:66,ignore",
+     make_dhcp_config ~macs:[Macaddr.of_string_exn "11:22:33:44:55:66"]
+       ~ignore:true ());
+    ("Eleventh dhcp-host from dnsmasq.conf.example",
+     "11:22:33:44:55:66,id:*",
+     make_dhcp_config ~id:`Any_client_id
+       ~macs:[Macaddr.of_string_exn "11:22:33:44:55:66"] ());
+    ("Twelvth dhcp-host from dnsmasq.conf.example",
+     "11:22:33:44:55:66,set:red",
+     make_dhcp_config ~macs:[Macaddr.of_string_exn "11:22:33:44:55:66"]
+       ~nets:["red"] ());
+    (* TODO:
+     ("Thirteenth dhcp-host from dnsmasq.conf.example",
+       "11:22:33:*:*:*,set:red",
+       _);
+     ("Fourteenth dhcp-host from dnsmasq.conf.example",
+       "id:00:01:00:01:16:d2:83:fc:92:d4:19:e2:d8:b2, fred, [1234::5]",
+       _);
+       *)
+  ]
+
 let tests =
   [
     ("DHCP range", `Quick, ok_dhcp_range);
     ("DHCP range with netmask", `Quick, ok_dhcp_range_with_netmask);
     ("DHCP range static", `Quick, ok_dhcp_range_static);
-  ]
+    ("DHCP host thedoctor", `Quick, ok_dhcp_host_thedoctor);
+    ("DHCP host tardis", `Quick, ok_dhcp_host_tardis);
+    ("DHCP host sonicscrewdriver", `Quick, ok_dhcp_host_sonicscrewdriver);
+    ("DHCP host apollon", `Quick, ok_dhcp_host_apollon);
+  ] @
+  ok_dhcp_host_dnsmasq_conf_example
 
 let string_of_file filename =
   let config_dir = "sample-configuration-files" in

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -11,9 +11,7 @@ let opt_eq f a b =
   | None, Some _ | Some _, None -> false
 
 let ipv4_eq a b = Ipaddr.V4.compare a b = 0
-
 let ipv6_eq a b = Ipaddr.V6.compare a b = 0
-
 let mac_eq a b = Macaddr.compare a b = 0
 
 let mode_eq a b =
@@ -33,21 +31,23 @@ let dhcp_range_t =
   Alcotest.testable pp_dhcp_range equal
 
 let dhcp_host_t =
-  let equal { id; nets; tags; macs; ipv4; ipv6; lease_time; ignore; domain_name } b =
-    Option.equal (fun id id' ->
-        match id, id' with
+  let equal
+      { id; nets; tags; macs; ipv4; ipv6; lease_time; ignore; domain_name } b =
+    Option.equal
+      (fun id id' ->
+        match (id, id') with
         | `Any_client_id, `Any_client_id -> true
         | `Client_id id, `Client_id id' -> String.equal id id'
         | `Any_client_id, `Client_id _ | `Client_id _, `Any_client_id -> false)
-      id b.id &&
-    List.equal String.equal nets b.nets &&
-    List.equal String.equal tags b.tags &&
-    List.equal mac_eq macs b.macs &&
-    Option.equal ipv4_eq ipv4 b.ipv4 &&
-    Option.equal ipv6_eq ipv6 b.ipv6 &&
-    Option.equal Int.equal lease_time b.lease_time &&
-    Bool.equal ignore b.ignore &&
-    Option.equal Domain_name.equal domain_name b.domain_name
+      id b.id
+    && List.equal String.equal nets b.nets
+    && List.equal String.equal tags b.tags
+    && List.equal mac_eq macs b.macs
+    && Option.equal ipv4_eq ipv4 b.ipv4
+    && Option.equal ipv6_eq ipv6 b.ipv6
+    && Option.equal Int.equal lease_time b.lease_time
+    && Bool.equal ignore b.ignore
+    && Option.equal Domain_name.equal domain_name b.domain_name
   in
   Alcotest.testable pp_dhcp_config equal
 
@@ -109,126 +109,152 @@ let ok_dhcp_range_static () =
       "DHCP range with static is good" (Ok expected)
       (parse_one_arg dhcp_range input))
 
-let make_dhcp_config ?id ?(nets=[]) ?(tags=[]) ?(macs=[]) ?ipv4 ?ipv6 ?lease_time ?(ignore=false) ?domain_name () =
+let make_dhcp_config ?id ?(nets = []) ?(tags = []) ?(macs = []) ?ipv4 ?ipv6
+    ?lease_time ?(ignore = false) ?domain_name () =
   { id; nets; tags; macs; ipv4; ipv6; lease_time; ignore; domain_name }
 
 let ok_dhcp_host_thedoctor () =
   let input = "00:00:5e:00:53:42,thedoctor,192.168.0.10" in
   let expected =
     make_dhcp_config
-      ~macs:[Macaddr.of_string_exn "00:00:5e:00:53:42"]
+      ~macs:[ Macaddr.of_string_exn "00:00:5e:00:53:42" ]
       ~domain_name:(Domain_name.of_string_exn "thedoctor")
       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.10")
       ()
   in
-  Alcotest.(check (result dhcp_host_t msg_t)) "DHCP host thedoctor is good"
-    (Ok expected) (parse_one_arg dhcp_host input)
+  Alcotest.(check (result dhcp_host_t msg_t))
+    "DHCP host thedoctor is good" (Ok expected)
+    (parse_one_arg dhcp_host input)
 
 let ok_dhcp_host_tardis () =
   let input = "00:00:5e:00:53:01,00:00:5e:00:53:02,tardis,192.168.0.22" in
   let expected =
     make_dhcp_config
-      ~macs:Macaddr.[of_string_exn "00:00:5e:00:53:01";
-                     of_string_exn "00:00:5e:00:53:02"]
+      ~macs:
+        Macaddr.
+          [
+            of_string_exn "00:00:5e:00:53:01"; of_string_exn "00:00:5e:00:53:02";
+          ]
       ~domain_name:(Domain_name.of_string_exn "tardis")
       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.22")
       ()
   in
-  Alcotest.(check (result dhcp_host_t msg_t)) "DHCP host tardis is good"
-    (Ok expected) (parse_one_arg dhcp_host input)
+  Alcotest.(check (result dhcp_host_t msg_t))
+    "DHCP host tardis is good" (Ok expected)
+    (parse_one_arg dhcp_host input)
 
 let ok_dhcp_host_sonicscrewdriver () =
   let input = "00:00:5e:00:53:08,sonicscrewdriver,192.168.0.23" in
   let expected =
     make_dhcp_config
-      ~macs:[Macaddr.of_string_exn "00:00:5e:00:53:08"]
+      ~macs:[ Macaddr.of_string_exn "00:00:5e:00:53:08" ]
       ~domain_name:(Domain_name.of_string_exn "sonicscrewdriver")
       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.23")
       ()
   in
-  Alcotest.(check (result dhcp_host_t msg_t)) "DHCP host sonicscrewdriver is good"
-    (Ok expected) (parse_one_arg dhcp_host input)
+  Alcotest.(check (result dhcp_host_t msg_t))
+    "DHCP host sonicscrewdriver is good" (Ok expected)
+    (parse_one_arg dhcp_host input)
 
 let ok_dhcp_host_apollon () =
   let input = "52:54:00:42:6a:43,apollon,10.10.10.51,infinite" in
   let expected =
     make_dhcp_config
-      ~macs:[Macaddr.of_string_exn "52:54:00:42:6a:43"]
+      ~macs:[ Macaddr.of_string_exn "52:54:00:42:6a:43" ]
       ~domain_name:(Domain_name.of_string_exn "apollon")
       ~ipv4:(Ipaddr.V4.of_string_exn "10.10.10.51")
       ~lease_time:(1 lsl 32) (* infinite *)
       ()
   in
-  Alcotest.(check (result dhcp_host_t msg_t)) "DHCP host apollon is good"
-    (Ok expected) (parse_one_arg dhcp_host input)
+  Alcotest.(check (result dhcp_host_t msg_t))
+    "DHCP host apollon is good" (Ok expected)
+    (parse_one_arg dhcp_host input)
 
 let ok_dhcp_host_dnsmasq_conf_example =
   let to_test (name, input, expected) =
-    (name, `Quick, fun () ->
+    ( name,
+      `Quick,
+      fun () ->
         Alcotest.(check (result dhcp_host_t msg_t))
-          (name ^ " is good")
-          (Ok expected)
-          (parse_one_arg dhcp_host input))
+          (name ^ " is good") (Ok expected)
+          (parse_one_arg dhcp_host input) )
   in
-  List.map to_test [
-    ("First dhcp-host from dnsmasq.conf.example",
-     "11:22:33:44:55:66,192.168.0.60",
-     make_dhcp_config ~macs:[Macaddr.of_string_exn "11:22:33:44:55:66"]
-       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60") ());
-    ("Second dhcp-host from dnsmasq.conf.example",
-     "11:22:33:44:55:66,fred",
-     make_dhcp_config ~macs:[Macaddr.of_string_exn "11:22:33:44:55:66"]
-       ~domain_name:(Domain_name.of_string_exn "fred") ());
-    ("Third dhcp-host from dnsmasq.conf.example",
-     "11:22:33:44:55:66,fred,192.168.0.60,45m",
-     make_dhcp_config ~macs:[Macaddr.of_string_exn "11:22:33:44:55:66"]
-       ~domain_name:(Domain_name.of_string_exn "fred")
-       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60")
-       ~lease_time:(45*60) ());
-    ("Fourth dhcp-host from dnsmasq.conf.example",
-     "11:22:33:44:55:66,12:34:56:78:90:12,192.168.0.60",
-     make_dhcp_config ~macs:Macaddr.[of_string_exn "11:22:33:44:55:66";
-                                     of_string_exn "12:34:56:78:90:12"]
-       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60") ());
-    ("Fifth dhcp-host from dnsmasq.conf.example",
-     "bert,192.168.0.70,infinite",
-     make_dhcp_config ~domain_name:(Domain_name.of_string_exn "bert")
-       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.70")
-       ~lease_time:(1 lsl 32) ());
-    ("Sixth dhcp-host from dnsmasq.conf.example",
-     "id:01:02:02:04,192.168.0.60",
-     make_dhcp_config ~id:(`Client_id "\x01\x02\x02\x04")
-       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60") ());
-    (* skipping seventh as it's similar to above, but is infiniband in a manner we wouldn't care about *)
-    ("Eigth dhcp-host from dnsmasq.conf.example",
-     "id:marjorie,192.168.0.60",
-     make_dhcp_config ~id:(`Client_id "marjorie")
-       ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60") ());
-    ("Ninth dhcp-host from dnsmasq.conf.example",
-     "judge",
-     make_dhcp_config ~domain_name:(Domain_name.of_string_exn "judge")
-       ());
-    ("Tenth dhcp-host from dnsmasq.conf.example",
-     "11:22:33:44:55:66,ignore",
-     make_dhcp_config ~macs:[Macaddr.of_string_exn "11:22:33:44:55:66"]
-       ~ignore:true ());
-    ("Eleventh dhcp-host from dnsmasq.conf.example",
-     "11:22:33:44:55:66,id:*",
-     make_dhcp_config ~id:`Any_client_id
-       ~macs:[Macaddr.of_string_exn "11:22:33:44:55:66"] ());
-    ("Twelvth dhcp-host from dnsmasq.conf.example",
-     "11:22:33:44:55:66,set:red",
-     make_dhcp_config ~macs:[Macaddr.of_string_exn "11:22:33:44:55:66"]
-       ~nets:["red"] ());
-    (* TODO:
-     ("Thirteenth dhcp-host from dnsmasq.conf.example",
-       "11:22:33:*:*:*,set:red",
-       _);
-     ("Fourteenth dhcp-host from dnsmasq.conf.example",
-       "id:00:01:00:01:16:d2:83:fc:92:d4:19:e2:d8:b2, fred, [1234::5]",
-       _);
-       *)
-  ]
+  List.map to_test
+    [
+      ( "First dhcp-host from dnsmasq.conf.example",
+        "11:22:33:44:55:66,192.168.0.60",
+        make_dhcp_config
+          ~macs:[ Macaddr.of_string_exn "11:22:33:44:55:66" ]
+          ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60")
+          () );
+      ( "Second dhcp-host from dnsmasq.conf.example",
+        "11:22:33:44:55:66,fred",
+        make_dhcp_config
+          ~macs:[ Macaddr.of_string_exn "11:22:33:44:55:66" ]
+          ~domain_name:(Domain_name.of_string_exn "fred")
+          () );
+      ( "Third dhcp-host from dnsmasq.conf.example",
+        "11:22:33:44:55:66,fred,192.168.0.60,45m",
+        make_dhcp_config
+          ~macs:[ Macaddr.of_string_exn "11:22:33:44:55:66" ]
+          ~domain_name:(Domain_name.of_string_exn "fred")
+          ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60")
+          ~lease_time:(45 * 60) () );
+      ( "Fourth dhcp-host from dnsmasq.conf.example",
+        "11:22:33:44:55:66,12:34:56:78:90:12,192.168.0.60",
+        make_dhcp_config
+          ~macs:
+            Macaddr.
+              [
+                of_string_exn "11:22:33:44:55:66";
+                of_string_exn "12:34:56:78:90:12";
+              ]
+          ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60")
+          () );
+      ( "Fifth dhcp-host from dnsmasq.conf.example",
+        "bert,192.168.0.70,infinite",
+        make_dhcp_config
+          ~domain_name:(Domain_name.of_string_exn "bert")
+          ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.70")
+          ~lease_time:(1 lsl 32) () );
+      ( "Sixth dhcp-host from dnsmasq.conf.example",
+        "id:01:02:02:04,192.168.0.60",
+        make_dhcp_config ~id:(`Client_id "\x01\x02\x02\x04")
+          ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60")
+          () );
+      (* skipping seventh as it's similar to above, but is infiniband in a manner we wouldn't care about *)
+      ( "Eigth dhcp-host from dnsmasq.conf.example",
+        "id:marjorie,192.168.0.60",
+        make_dhcp_config ~id:(`Client_id "marjorie")
+          ~ipv4:(Ipaddr.V4.of_string_exn "192.168.0.60")
+          () );
+      ( "Ninth dhcp-host from dnsmasq.conf.example",
+        "judge",
+        make_dhcp_config ~domain_name:(Domain_name.of_string_exn "judge") () );
+      ( "Tenth dhcp-host from dnsmasq.conf.example",
+        "11:22:33:44:55:66,ignore",
+        make_dhcp_config
+          ~macs:[ Macaddr.of_string_exn "11:22:33:44:55:66" ]
+          ~ignore:true () );
+      ( "Eleventh dhcp-host from dnsmasq.conf.example",
+        "11:22:33:44:55:66,id:*",
+        make_dhcp_config ~id:`Any_client_id
+          ~macs:[ Macaddr.of_string_exn "11:22:33:44:55:66" ]
+          () );
+      ( "Twelvth dhcp-host from dnsmasq.conf.example",
+        "11:22:33:44:55:66,set:red",
+        make_dhcp_config
+          ~macs:[ Macaddr.of_string_exn "11:22:33:44:55:66" ]
+          ~nets:[ "red" ] () );
+      (* TODO:
+         ("Thirteenth dhcp-host from dnsmasq.conf.example",
+           "11:22:33:*:*:*,set:red",
+           _);
+         ("Fourteenth dhcp-host from dnsmasq.conf.example",
+           "id:00:01:00:01:16:d2:83:fc:92:d4:19:e2:d8:b2, fred, [1234::5]",
+           _);
+      *)
+    ]
 
 let tests =
   [
@@ -239,8 +265,8 @@ let tests =
     ("DHCP host tardis", `Quick, ok_dhcp_host_tardis);
     ("DHCP host sonicscrewdriver", `Quick, ok_dhcp_host_sonicscrewdriver);
     ("DHCP host apollon", `Quick, ok_dhcp_host_apollon);
-  ] @
-  ok_dhcp_host_dnsmasq_conf_example
+  ]
+  @ ok_dhcp_host_dnsmasq_conf_example
 
 let string_of_file filename =
   let config_dir = "sample-configuration-files" in


### PR DESCRIPTION
I think the parser is more or less there. I plan on adding tests.

I still don't quite understand how all the values are to be used. We may want to error out on certain values and combinations. Part of the values are for matching a client, some are values to assign to the client. Then we have the `ignore` flag which means we should **not** handle a client matching - in that case the values to assign have questionable meaning.

Dnsmasq uses a function `parse_hex()` for parsing mac addresses but also `id:`s if there are any colons in the id value. The function is really obscure, and allows you to write an id `id:41------424344:*:*:*:*` that, likely due to a safety bug, is the same as `id:ABCD----`. There's a lot of nonsense in there that I don't think we should support.

Mac address parsing could as well be improved. In particular there's no wildcards yet (you can write a mac address "pattern" `00:11:*:*:44:55` where the middle two bytes match any value).