### PR TITLE
display statistics from dns resolver

### DIFF
--- a/mirage/statistics.ml
+++ b/mirage/statistics.ml
@@ -1,4 +1,4 @@
-let statistics_page =
+let statistics_page stats =
   Tyxml_html.(
     main
       ~a:[ a_class [ "w-full text-gray-900" ] ]
@@ -41,10 +41,10 @@ let statistics_page =
                       [
                         div
                           ~a:[ a_class [ "text-sm" ] ]
-                          [ txt "Total queries (5 clients)" ];
+                          [ txt ("Total queries (" ^ string_of_int (Ipaddr.Set.cardinal stats.Dns_resolver.clients) ^ " clients)") ];
                         div
                           ~a:[ a_class [ "text-2xl font-bold" ] ]
-                          [ txt "3,416" ];
+                          [ txt (string_of_int stats.queries) ];
                       ];
                     div
                       ~a:
@@ -58,7 +58,7 @@ let statistics_page =
                           [ txt "Queries Blocked" ];
                         div
                           ~a:[ a_class [ "text-2xl font-bold" ] ]
-                          [ txt "491" ];
+                          [ txt (string_of_int stats.blocked) ];
                       ];
                     div
                       ~a:
@@ -72,7 +72,7 @@ let statistics_page =
                           [ txt "Percent Blocked" ];
                         div
                           ~a:[ a_class [ "text-2xl font-bold" ] ]
-                          [ txt "14.4%" ];
+                          [ txt (Fmt.str "%.1f%%" (float_of_int stats.blocked /. float_of_int stats.queries)) ];
                       ];
                     div
                       ~a:
@@ -86,7 +86,7 @@ let statistics_page =
                           [ txt "Domains on Blocklist" ];
                         div
                           ~a:[ a_class [ "text-2xl font-bold" ] ]
-                          [ txt "82,309" ];
+                          [ txt (string_of_int 0 (* TODO (List.length blocklist) *)) ];
                       ];
                   ];
                 div

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -376,8 +376,9 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
           | `GET, "/main.js" ->
               reply ~content_type:"text/javascript" reqd js_file
           | `GET, "/" | `GET, "/dashboard" ->
+              let stats = Resolver.stats resolver in
               reply reqd
-                (Dashboard.dashboard_layout ~content:Statistics.statistics_page
+                (Dashboard.dashboard_layout ~content:(Statistics.statistics_page stats)
                    ())
           | `GET, "/querylog" ->
               reply reqd
@@ -385,10 +386,6 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
           | `GET, "/blocklist" ->
               reply reqd
                 (Dashboard.dashboard_layout ~content:Blocklist.block_page ())
-          | `GET, "/config" ->
-              reply reqd
-                (Dashboard.dashboard_layout ~content:Statistics.statistics_page
-                   ())
           | `GET, path when String.starts_with ~prefix:"/dns-query" path ->
               let target = request.H2.Request.target in
               let elts = String.split_on_char '=' target in


### PR DESCRIPTION
needs to use https://github.com/mirage/ocaml-dns/pull/376 (so cI here will fail).

the question is what other statistics are of interest? I'd recommend to delete the time series graphs (for now), and delay that to a later time.

Interesting may be:
- memory usage (GC)
- cache sizes (esp. the dns_cache)
- mean response time
- DNS errors received
- authoritative requests send & received
- DNS timeouts
- protocol usage: UDP, TCP, DoT
- outstanding client queries & outstanding authoritative queries

I suggest we for now just display these numbers. And work on graphs at a later point in time (we'll need to store metrics etc.). WDYT?