### PR TITLE
Disable primary trie cache

### DIFF
--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -821,7 +821,8 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
           (Blocklist.add_single_block "boot-parameter")
           trie (K.dns_block ())
       in
-      Dns_server.Primary.create ~rng:Mirage_crypto_rng.generate trie
+      Dns_server.Primary.create ~trie_cache_entries:0
+        ~rng:Mirage_crypto_rng.generate trie
     in
     (match K.dns_upstream () with
     | None ->


### PR DESCRIPTION
We don't support secondaries, so no reason to cache things. With this change I can refresh indefinitely with the lists https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts and https://v.firebog.net/hosts/static/w3kbl.txt with 128 MB memory assigned. Before this patch I could refresh once and on the second refresh it would run out of memory.

This depends on https://github.com/mirage/ocaml-dns/pull/387.