### PR TITLE
Configuration UI

### DIFF
--- a/mirage/assets/main.js
+++ b/mirage/assets/main.js
@@ -1,1 +1,28 @@
-console.log("DNSvizor")
+
+document.addEventListener('DOMContentLoaded', () => {
+    const fileInput = document.getElementById('dnsmasq_config_file');
+    const selectedFileNameSpan = document.getElementById('selected_file_name');
+    const fileContentDisplayArea = document.getElementById('file_content_display');
+
+    // Listen for changes on the hidden file input
+    fileInput.addEventListener('change', (event) => {
+        const file = event.target.files[0]; // Get the first selected file
+
+        if (file) {
+            selectedFileNameSpan.textContent = file.name;
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                fileContentDisplayArea.value = e.target.result;
+            };
+            reader.onerror = () => {
+                selectedFileNameSpan.textContent = "Error reading file.";
+                fileContentDisplayArea.value = "Could not read file content.";
+                console.error("Error reading file:", reader.error);
+            };
+            reader.readAsText(file);
+        } else {
+            selectedFileNameSpan.textContent = "No file chosen";
+            fileContentDisplayArea.value = "";
+        }
+    });
+});

--- a/mirage/assets/main.js
+++ b/mirage/assets/main.js
@@ -2,7 +2,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     const fileInput = document.getElementById('dnsmasq_config_file');
     const selectedFileNameSpan = document.getElementById('selected_file_name');
-    const fileContentDisplayArea = document.getElementById('file_content_display');
+    const fileContentDisplayArea = document.getElementById('dnsmasq_config');
 
     // Listen for changes on the hidden file input
     fileInput.addEventListener('change', (event) => {

--- a/mirage/configuration.ml
+++ b/mirage/configuration.ml
@@ -1,0 +1,133 @@
+let configuration_page =
+  Tyxml_html.(
+    main
+      ~a:[ a_class [ "w-full text-gray-900" ] ]
+      [
+        section
+          ~a:
+            [
+              a_class [ "relative mx-auto px-4 sm:px-6 lg:px-8 py-10 xl:pb-32" ];
+            ]
+          [
+            section
+              ~a:[ a_class [ "px-4 py-6 w-full" ] ]
+              [
+                h2
+                  ~a:[ a_class [ "text-xl font-bold text-cyan-800 mb-4" ] ]
+                  [ txt "DNSmasq Configuration Upload" ];
+                p
+                  ~a:[ a_class [ "mb-6 text-gray-700" ] ]
+                  [
+                    txt
+                      "Upload your complete DNSmasq configuration file (.conf) \
+                       here. All DNSmasq options are managed directly within \
+                       this file.";
+                  ];
+                form
+                  ~a:
+                    [
+                      a_action "/configuration/upload";
+                      a_method `Post;
+                      a_enctype "multipart/form-data";
+                      a_class [ "bg-white p-6 rounded-lg shadow-md" ];
+                    ]
+                  [
+                    div
+                      ~a:[ a_class [ "mb-4" ] ]
+                      [
+                        label
+                          ~a:
+                            [
+                              a_class
+                                [
+                                  "block text-sm font-medium text-gray-700 mb-2";
+                                ];
+                            ]
+                          [ txt "Select DNSmasq Configuration File:" ];
+                        (* Hidden file input *)
+                        input
+                          ~a:
+                            [
+                              a_input_type `File;
+                              a_id "dnsmasq_config_file";
+                              a_name "dnsmasq_config_file";
+                              a_class [ "hidden" ];
+                              a_accept [ ".conf"; ".txt" ];
+                            ]
+                          ();
+                        div
+                          ~a:
+                            [
+                              a_onclick
+                                "document.getElementById('dnsmasq_config_file').click()";
+                              (* JavaScript to click the hidden input *)
+                              a_class
+                                [
+                                  "inline-block px-4 py-2 bg-gray-200 \
+                                   text-gray-800 rounded-md hover:bg-gray-300 \
+                                   focus:outline-none focus:ring-2 \
+                                   focus:ring-gray-400 focus:ring-opacity-75 \
+                                   cursor-pointer transition-colors \
+                                   duration-200";
+                                ];
+                            ]
+                          [ txt "Choose File" ];
+                        span
+                          ~a:
+                            [
+                              a_id "selected_file_name";
+                              a_class [ "ml-3 text-gray-600 italic" ];
+                            ]
+                          [ txt "No file chosen" ];
+                      ];
+                    div
+                      ~a:[ a_class [ "mb-6" ] ]
+                      [
+                        label
+                          ~a:
+                            [
+                              a_class
+                                [
+                                  "block text-sm font-medium text-gray-700 mb-2";
+                                ];
+                            ]
+                          [ txt "DNSmasq config preview:" ];
+                        textarea
+                          ~a:
+                            [
+                              a_id "file_content_display";
+                              a_name "file_content_preview";
+                              a_rows 15;
+                              a_class
+                                [
+                                  "block w-full p-3 border border-gray-300 \
+                                   rounded-lg bg-gray-50 text-gray-800 \
+                                   font-mono text-sm resize-y \
+                                   focus:outline-none focus:border-blue-500 \
+                                   focus:ring-1 focus:ring-blue-500";
+                                ];
+                              a_readonly ();
+                              (* Make it read-only for preview *)
+                            ]
+                          (txt "");
+                      ];
+                    div
+                      ~a:[ a_class [ "flex justify-end" ] ]
+                      [
+                        button
+                          ~a:
+                            [
+                              a_class
+                                [
+                                  "px-6 py-2 bg-cyan-600 text-white rounded-md \
+                                   hover:bg-cyan-700 focus:outline-none \
+                                   focus:ring-2 focus:ring-cyan-500 \
+                                   focus:ring-opacity-50";
+                                ];
+                            ]
+                          [ txt "Upload Configuration" ];
+                      ];
+                  ];
+              ];
+          ];
+      ])

--- a/mirage/configuration.ml
+++ b/mirage/configuration.ml
@@ -95,8 +95,8 @@ let configuration_page =
                         textarea
                           ~a:
                             [
-                              a_id "file_content_display";
-                              a_name "file_content_preview";
+                              a_id "dnsmasq_config";
+                              a_name "dnsmasq_config";
                               a_rows 15;
                               a_class
                                 [
@@ -106,8 +106,6 @@ let configuration_page =
                                    focus:outline-none focus:border-blue-500 \
                                    focus:ring-1 focus:ring-blue-500";
                                 ];
-                              a_readonly ();
-                              (* Make it read-only for preview *)
                             ]
                           (txt "");
                       ];
@@ -125,7 +123,7 @@ let configuration_page =
                                    focus:ring-opacity-50";
                                 ];
                             ]
-                          [ txt "Upload Configuration" ];
+                          [ txt "Save Configuration" ];
                       ];
                   ];
               ];

--- a/mirage/dashboard.ml
+++ b/mirage/dashboard.ml
@@ -110,6 +110,28 @@ let dashboard_layout ?(page_title = "Dashboard | DNSvizor") ~content () =
                                [];
                              span [ txt "Block list" ];
                            ];
+                         a
+                           ~a:
+                             [
+                               a_href "/configuration";
+                               a_class
+                                 [
+                                   "hover:bg-cyan-200 hover:text-cyan-500 \
+                                    font-semibold hover:font-bold \
+                                    cursor-pointer rounded p-4 w-full flex \
+                                    items-center space-x-1";
+                                 ];
+                             ]
+                           [
+                             i
+                               ~a:
+                                 [
+                                   a_class
+                                     [ "fa-solid fa-cog text-cyan-500 text-sm" ];
+                                 ]
+                               [];
+                             span [ txt "Configuration" ];
+                           ];
                        ];
                    ];
                  section

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -1,5 +1,4 @@
 open Lwt.Infix
-open Dnsvizor.Config_parser
 
 module CA = struct
   let prefix =
@@ -519,7 +518,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
                       Logs.err (fun m -> m "No dnsmasq config file uploaded");
                       Some (`Bad_request ("/configuration", None))
                   | Some (_, config_file) -> (
-                      match parse_file config_file with
+                      match Dnsvizor.Config_parser.parse_file config_file with
                       | Ok _parsed_dnsmasq_config ->
                           (*TODO: handle configuration file properly*)
                           Logs.info (fun m ->

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -520,7 +520,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
                       Some (`Bad_request ("/configuration", None))
                   | Some (_, config_file) -> (
                       match parse_file config_file with
-                      | Ok _parse_file ->
+                      | Ok _parsed_dnsmasq_config ->
                           (*TODO: handle configuration file properly*)
                           Logs.info (fun m ->
                               m "Dnsmasq config file parsed correctly");

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -513,21 +513,20 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
                   Some (`Bad_request ("/configuration", None))
               | Ok (m, assoc) -> (
                   let multipart_body, _r = to_map ~assoc m in
-                  match Map.find_opt "dnsmasq_config_file" multipart_body with
+                  match Map.find_opt "dnsmasq_config" multipart_body with
                   | None ->
-                      Logs.err (fun m -> m "No dnsmasq config file uploaded");
+                      Logs.err (fun m -> m "No dnsmasq config provided");
                       Some (`Bad_request ("/configuration", None))
                   | Some (_, config_file) -> (
                       match Dnsvizor.Config_parser.parse_file config_file with
                       | Ok _parsed_dnsmasq_config ->
                           (*TODO: handle configuration file properly*)
                           Logs.info (fun m ->
-                              m "Dnsmasq config file parsed correctly");
+                              m "Dnsmasq config parsed correctly");
                           None
                       | Error (`Msg err) ->
                           Logs.err (fun m ->
-                              m "Error parsing dnsmasq configuration file: %s"
-                                err);
+                              m "Error parsing dnsmasq configuration: %s" err);
                           Some (`Bad_request ("/configuration", None))))))
       | `POST _, s when String.starts_with s ~prefix:"/blocklist/delete/" -> (
           (* NOTE: here we don't need the body because we embed in the path *)

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -505,20 +505,19 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
           in
           match Multipart_form.Content_type.of_string content_type with
           | Error (`Msg e) ->
-              (* FIXME: bad request I guess *)
               Logs.err (fun m -> m "Bad content-type header: %s" e);
-              Some (`Redirect ("/configuraton", None))
+              Some (`Bad_request ("/configuraton", None))
           | Ok ct -> (
               match Multipart_form.of_string_to_list data ct with
               | Error (`Msg e) ->
                   Logs.err (fun m -> m "Error parsing form: %s" e);
-                  Some (`Redirect ("/configuration", None))
+                  Some (`Bad_request ("/configuration", None))
               | Ok (m, assoc) -> (
                   let multipart_body, _r = to_map ~assoc m in
                   match Map.find_opt "dnsmasq_config_file" multipart_body with
                   | None ->
                       Logs.err (fun m -> m "No dnsmasq config file uploaded");
-                      Some (`Redirect ("/configuration", None))
+                      Some (`Bad_request ("/configuration", None))
                   | Some (_, config_file) -> (
                       match parse_file config_file with
                       | Ok _parse_file ->
@@ -530,7 +529,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
                           Logs.err (fun m ->
                               m "Error parsing dnsmasq configuration file: %s"
                                 err);
-                          Some (`Redirect ("/configuration", None))))))
+                          Some (`Bad_request ("/configuration", None))))))
       | `POST _, s when String.starts_with s ~prefix:"/blocklist/delete/" -> (
           (* NOTE: here we don't need the body because we embed in the path *)
           let off = String.length "/blocklist/delete/" in


### PR DESCRIPTION
This PR adds UI for uploading a dnsmasq configuration file. On the UI, we dumb the contents of the file to a textarea for preview. The form is set to accept only `.conf` and `.txt` files.

![image](https://github.com/user-attachments/assets/449fcab4-cbdf-4c91-8932-7b794d512628)
