### PR TITLE
Add a block device for config data

### DIFF
--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -36,9 +36,12 @@ let dnsvizor =
       package "http-mirage-client";
       package "angstrom";
       package "multipart_form";
+      package "oneffs";
     ]
   in
-  main ~packages "Unikernel.Main" (network @-> kv_ro @-> job)
+  main ~packages "Unikernel.Main" (network @-> kv_ro @-> block @-> job)
+
+let block = block_of_file "data"
 
 (* this works around the [default_network] on Unix brings a --interface runtime
    argument that collides with dnsmasq arguments *)
@@ -115,5 +118,5 @@ let () =
     [
       optional_syslog management_stack;
       optional_monitoring management_stack;
-      dnsvizor $ mynetwork $ assets;
+      dnsvizor $ mynetwork $ assets $ block;
     ]

--- a/mirage/storage.ml
+++ b/mirage/storage.ml
@@ -1,0 +1,35 @@
+let error_msgf fmt = Fmt.kstr (fun msg -> Error (`Msg msg)) fmt
+
+module Make (BLOCK : Mirage_block.S) = struct
+  module Stored_data = OneFFS.Make (BLOCK)
+  open Lwt.Infix
+
+  type t = { disk : Stored_data.t; mutable configuration : string option }
+
+  let write_data t =
+    Stored_data.write t.disk (Option.value ~default:"" t.configuration)
+
+  let read_data disk =
+    Stored_data.read disk >|= function
+    | Ok (Some s) -> Ok (Some s)
+    | Ok None -> Ok None
+    | Error e ->
+        error_msgf "error while reading storage: %a" Stored_data.pp_error e
+
+  let connect block =
+    Stored_data.connect block >>= fun disk ->
+    read_data disk >|= function
+    | Error _ as e -> e
+    | Ok configuration -> Ok { disk; configuration }
+
+  let update_configuration t configuration =
+    let t' = { t with configuration } in
+    write_data t' >|= function
+    | Ok () ->
+        t.configuration <- configuration;
+
+        Ok ()
+    | Error we ->
+        error_msgf "error while writing storage: %a" Stored_data.pp_write_error
+          we
+end

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -1064,11 +1064,9 @@ struct
                 (Mirage_mtime.elapsed_ns ())
                 Mirage_crypto_rng.generate primary_t
             in
-            let password = K.password () in
 
             Lwt.async (fun () ->
-                Daemon.start_resolver t stack tcp resolver http_client js_file
-                  password);
+                Daemon.start_resolver t stack tcp resolver http_client js_file);
             Lwt.return_unit
         | Some ns -> (
             Logs.info (fun m -> m "using a stub resolver, forwarding to %s" ns);

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -235,7 +235,8 @@ module K = struct
     Mirage_runtime.register_arg arg
 end
 
-module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
+module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) (BLOCK : Mirage_block.S) =
+struct
   type t = {
     mac : Macaddr.t;
     mutable configuration : string;
@@ -417,6 +418,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
   module Mimic_he = Mimic_happy_eyeballs.Make (S) (HE) (Dns_client)
   module Http_client = Http_mirage_client.Make (TCP) (Mimic_he)
   module Map = Map.Make (String)
+  module Store = Storage.Make (BLOCK)
 
   module Daemon = struct
     let pp_error ppf = function
@@ -980,7 +982,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
       Lwt.join [ th; go (cert, dns_tls, tls) resolver mvar ]
   end
 
-  let start net assets =
+  let start net assets block =
     let t = of_commandline (N.mac net) () in
     let net = Net.connect net t in
     ETH.connect net >>= fun eth ->
@@ -1042,33 +1044,41 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
       Dns_server.Primary.create ~rng:Mirage_crypto_rng.generate trie
     in
     js_file assets >>= fun js_file ->
-    (match K.dns_upstream () with
-    | None ->
-        Logs.info (fun m -> m "using a recursive resolver");
-        let resolver =
-          let features =
-            (if K.dnssec () then [ `Dnssec ] else [])
-            @ (if K.qname_minimisation () then [ `Qname_minimisation ] else [])
-            @
-            if K.opportunistic_tls () then [ `Opportunistic_tls_authoritative ]
-            else []
-          in
-          Dns_resolver.create ?cache_size:(K.dns_cache ()) features
-            (Mirage_mtime.elapsed_ns ())
-            Mirage_crypto_rng.generate primary_t
-        in
-        Lwt.async (fun () ->
-            Daemon.start_resolver t stack tcp resolver http_client js_file);
-        Lwt.return_unit
-    | Some ns -> (
-        Logs.info (fun m -> m "using a stub resolver, forwarding to %s" ns);
-        Stub.H.connect_device stack >>= fun happy_eyeballs ->
-        try
-          Stub.create ?cache_size:(K.dns_cache ()) ~nameservers:[ ns ] primary_t
-            ~happy_eyeballs stack
-          >|= fun _ -> ()
-        with Invalid_argument a ->
-          Logs.err (fun m -> m "error %s" a);
-          exit Mirage_runtime.argument_error))
-    >>= fun () -> S.listen stack
+    Store.connect block >>= function
+    | Error (`Msg msg) -> failwith msg
+    | Ok store ->
+        (match K.dns_upstream () with
+        | None ->
+            Logs.info (fun m -> m "using a recursive resolver");
+            let resolver =
+              let features =
+                (if K.dnssec () then [ `Dnssec ] else [])
+                @ (if K.qname_minimisation () then [ `Qname_minimisation ]
+                   else [])
+                @
+                if K.opportunistic_tls () then
+                  [ `Opportunistic_tls_authoritative ]
+                else []
+              in
+              Dns_resolver.create ?cache_size:(K.dns_cache ()) features
+                (Mirage_mtime.elapsed_ns ())
+                Mirage_crypto_rng.generate primary_t
+            in
+            let password = K.password () in
+
+            Lwt.async (fun () ->
+                Daemon.start_resolver t stack tcp resolver http_client js_file
+                  password);
+            Lwt.return_unit
+        | Some ns -> (
+            Logs.info (fun m -> m "using a stub resolver, forwarding to %s" ns);
+            Stub.H.connect_device stack >>= fun happy_eyeballs ->
+            try
+              Stub.create ?cache_size:(K.dns_cache ()) ~nameservers:[ ns ]
+                primary_t ~happy_eyeballs stack
+              >|= fun _ -> ()
+            with Invalid_argument a ->
+              Logs.err (fun m -> m "error %s" a);
+              exit Mirage_runtime.argument_error))
+        >>= fun () -> S.listen stack
 end


### PR DESCRIPTION
This PR adds a block device and some functions to read and dump data onto the device.
The config data will be dumped as a simple plain text, as this is mostly what we want to store on the device.