### PR TITLE
Man sections

### DIFF
--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -104,8 +104,7 @@ module K = struct
   let dhcp_range =
     let doc =
       Arg.info ~doc:"Enable DHCP server." ~docv:Config_parser.dhcp_range_docv
-        ~docs:s_dnsmasq
-        [ "dhcp-range" ]
+        ~docs:s_dnsmasq [ "dhcp-range" ]
     in
     Mirage_runtime.register_arg
       Arg.(value & opt Config_parser.(some dhcp_range_c) None doc)
@@ -156,7 +155,8 @@ module K = struct
   (* Further configuration options, not ignored *)
   let dnssec =
     let doc =
-      Arg.info ~doc:"Validate DNS replies and cache DNSSEC data." ~docs:s_dnsmasq [ "dnssec" ]
+      Arg.info ~doc:"Validate DNS replies and cache DNSSEC data."
+        ~docs:s_dnsmasq [ "dnssec" ]
     in
     Mirage_runtime.register_arg Arg.(value & flag doc)
 


### PR DESCRIPTION
Addresses #52.

The order of the sections is now: `DNSMASQ-COMPATIBLE OPTIONS`, `OPTIONS`, remaining options (mostly Mirage options).