### PR TITLE
Provide a configuration flag, --no-tls, to disable web frontend and DoT/DoH

### DIFF
--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -64,12 +64,7 @@ let management_stack =
        (netif ~group:"management" "management"))
     (generic_stackv4v6 mynetwork)
 
-let name =
-  runtime_arg ~pos:__POS__
-    {|let doc = Cmdliner.Arg.info ~doc:"Name of the unikernel"
-        ~docs:Mirage_runtime.s_log [ "name" ]
-      in
-      Cmdliner.Arg.(value & opt string "robur.coop" doc)|}
+let name = runtime_arg ~pos:__POS__ "Unikernel.K.name_k"
 
 let monitoring =
   let monitor = Runtime_arg.(v (monitor None)) in
@@ -78,7 +73,7 @@ let monitoring =
         code ~pos:__POS__
           "Lwt.return (match %s with| None -> Logs.warn (fun m -> m \"no \
            monitor specified, not outputting statistics\")| Some ip -> \
-           %s.create ip ~hostname:%s %s)"
+           %s.create ip ~hostname:(Domain_name.to_string %s) %s)"
           monitor modname name stack
     | _ -> assert false
   in
@@ -94,7 +89,8 @@ let syslog =
         code ~pos:__POS__
           "Lwt.return (match %s with| None -> Logs.warn (fun m -> m \"no \
            syslog specified, dumping on stdout\")| Some ip -> \
-           Logs.set_reporter (%s.create %s ip ~hostname:%s ()))"
+           Logs.set_reporter (%s.create %s ip ~hostname:(Domain_name.to_string \
+           %s) ()))"
           syslog modname stack name
     | _ -> assert false
   in

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -153,6 +153,16 @@ module K = struct
     Mirage_runtime.register_arg Arg.(value & flag doc)
 
   (* Further configuration options, not ignored *)
+  let no_hosts =
+    let doc =
+      Arg.info
+        ~doc:
+          "Don't 'read' the (synthesized) /etc/hosts (contains only --name \
+           argument)"
+        [ "no-hosts" ]
+    in
+    Mirage_runtime.register_arg Arg.(value & flag doc)
+
   let dnssec =
     let doc =
       Arg.info ~doc:"Validate DNS replies and cache DNSSEC data."
@@ -235,7 +245,7 @@ module K = struct
     let doc = Arg.info ~doc:"Password used for authentication" [ "password" ] in
     Mirage_runtime.register_arg Arg.(value & opt (some string) None doc)
 
-  let name =
+  let name_k =
     let ( let* ) = Result.bind in
     let parser str =
       let* dn = Domain_name.of_string str in
@@ -244,24 +254,13 @@ module K = struct
     let pp = Domain_name.pp in
     let domain_name = Arg.conv (parser, pp) in
     let doc = "The name (and the SNI for the certificate) of the unikernel." in
-    let arg =
-      let open Arg in
-      required
-      & opt (some domain_name)
-          (Some Domain_name.(of_string_exn "dnsvizor" |> host_exn))
-      & info [ "name" ] ~doc
-    in
-    Mirage_runtime.register_arg arg
+    let open Arg in
+    required
+    & opt (some domain_name)
+        (Some Domain_name.(of_string_exn "dnsvizor" |> host_exn))
+    & info [ "name" ] ~doc
 
-  let no_hosts =
-    let doc =
-      Arg.info
-        ~doc:
-          "Don't 'read' the (synthesized) /etc/hosts (contains only --name \
-           argument)"
-        [ "no-hosts" ]
-    in
-    Mirage_runtime.register_arg Arg.(value & flag doc)
+  let name = Mirage_runtime.register_arg name_k
 end
 
 module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct


### PR DESCRIPTION
The reasoning is at the moment for extending and debugging, there's less noise if this is just not there.