### PR TITLE
Implement --dhcp-option=option:log-server,0.0.0.0

### DIFF
--- a/dnsvizor.opam
+++ b/dnsvizor.opam
@@ -26,7 +26,7 @@ depends: [
   "cmdliner" {>= "1.2.0"}
   "logs" {>= "0.7.0"}
   "ohex" {>= "0.2.0"}
-  "charrua"
+  "charrua" {>= "2.1.0"}
 
   "alcotest" {with-test & >= "1.8.0"}
 ]

--- a/dnsvizor.opam
+++ b/dnsvizor.opam
@@ -26,6 +26,7 @@ depends: [
   "cmdliner" {>= "1.2.0"}
   "logs" {>= "0.7.0"}
   "ohex" {>= "0.2.0"}
+  "charrua"
 
   "alcotest" {with-test & >= "1.8.0"}
 ]

--- a/src/config_parser.mli
+++ b/src/config_parser.mli
@@ -30,6 +30,13 @@ val pp_dhcp_host : dhcp_host Fmt.t
 val dhcp_host_docv : string
 val dhcp_host_c : dhcp_host Cmdliner.Arg.conv
 
+type dhcp_option = { tags : string list; option : Dhcp_wire.dhcp_option }
+
+val dhcp_option : unit Angstrom.t -> dhcp_option Angstrom.t
+val pp_dhcp_option : dhcp_option Fmt.t
+val dhcp_option_docv : string
+val dhcp_option_c : dhcp_option Cmdliner.Arg.conv
+
 type domain =
   [ `raw ] Domain_name.t
   * [ `Interface of string
@@ -44,7 +51,12 @@ val domain_c : domain Cmdliner.Arg.conv
 val ignore_c : string -> string Cmdliner.Arg.conv
 
 type config =
-  [ `Dhcp_range of dhcp_range | `Domain of domain | `Dnssec | `Ignored ] list
+  [ `Dhcp_range of dhcp_range
+  | `Domain of domain
+  | `Dhcp_option of dhcp_option
+  | `Dnssec
+  | `Ignored ]
+  list
 
 val parse_file : string -> (config, [> `Msg of string ]) result
 val arg_end_of_directive : unit Angstrom.t

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (name dnsvizor)
  (public_name dnsvizor)
- (libraries angstrom fmt ipaddr cmdliner logs ohex))
+ (libraries angstrom fmt ipaddr cmdliner logs ohex charrua))

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -336,12 +336,26 @@ let test_configuration config file () =
         "Number of configuration items matches" (List.length config)
         (List.length data)
 
+let dhcp_option_conf =
+  [
+    `Dhcp_option
+      { tags = []; option = Dhcp_wire.Log_servers [ Ipaddr.V4.localhost ] };
+    `Dhcp_option
+      {
+        tags = [ "naughties" ];
+        option = Dhcp_wire.Log_servers [ Ipaddr.V4.of_string_exn "8.8.8.8" ];
+      };
+  ]
+
 let config_file_tests =
   [
     ("First example", `Quick, test_configuration [] "simple.conf");
     ( "White space and comments",
       `Quick,
       test_configuration [] "whitespace-and-comments.conf" );
+    ( "dhcp-option",
+      `Quick,
+      test_configuration dhcp_option_conf "dhcp-option.conf" );
   ]
 
 let tests =

--- a/test/sample-configuration-files/dhcp-option.conf
+++ b/test/sample-configuration-files/dhcp-option.conf
@@ -1,0 +1,2 @@
+dhcp-option=option:log-server,127.0.0.1
+dhcp-option=tag:naughties,option:log-server,8.8.8.8


### PR DESCRIPTION
With this we can add dhcp options to send to clients. The logic for actually sending it is still missing. For now only the `log-server` / `Log_servers` dhcp option is handled.