### PR TITLE
support dns 10.2.2 (where some API was revised)

### DIFF
--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -17,7 +17,9 @@ let dnsvizor =
       package "dns-client-mirage";
       package "dnssec";
       package "dns-mirage";
-      package ~min:"10.2.2" ~sublibs:[ "mirage" ; "mirage.shared" ] "dns-resolver";
+      package ~min:"10.2.2"
+        ~sublibs:[ "mirage"; "mirage.shared" ]
+        "dns-resolver";
       package ~min:"10.2.1" ~sublibs:[ "mirage" ] "dns-stub";
       package "dns-tsig";
       package "dns-server";

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -1161,8 +1161,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
         Lwt.join [ th; go (cert, dns_tls, tls) mvar ]
   end
 
-  module Dhcp_dns (Resolver : Dns_resolver_mirage_shared.S) =
-  struct
+  module Dhcp_dns (Resolver : Dns_resolver_mirage_shared.S) = struct
     let update_dns tcp lease name =
       match (K.dns_key (), K.dns_server ()) with
       | Some (key_name, key), Some ip ->


### PR DESCRIPTION
see https://github.com/mirage/ocaml-dns/pull/396