### PR TITLE
Vendor specific options

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.27.0
+version = 0.28.1
 profile = conventional
 parse-docstrings = true

--- a/src/config_parser.mli
+++ b/src/config_parser.mli
@@ -30,7 +30,11 @@ val pp_dhcp_host : dhcp_host Fmt.t
 val dhcp_host_docv : string
 val dhcp_host_c : dhcp_host Cmdliner.Arg.conv
 
-type dhcp_option = { tags : string list; vendor : string option; option : Dhcp_wire.dhcp_option }
+type dhcp_option = {
+  tags : string list;
+  vendor : string option;
+  option : Dhcp_wire.dhcp_option;
+}
 
 val dhcp_option : unit Angstrom.t -> dhcp_option Angstrom.t
 val pp_dhcp_option : dhcp_option Fmt.t

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -367,7 +367,11 @@ let test_configuration config file () =
 let dhcp_option_conf =
   [
     `Dhcp_option
-      { tags = []; vendor = None; option = Dhcp_wire.Log_servers [ Ipaddr.V4.localhost ] };
+      {
+        tags = [];
+        vendor = None;
+        option = Dhcp_wire.Log_servers [ Ipaddr.V4.localhost ];
+      };
     `Dhcp_option
       {
         tags = [ "naughties" ];


### PR DESCRIPTION
This adds:
- vendor specific options (either hex or plain string - this is somewhat incompatible with dnsmasq as things that look like ip addresses are not transformed into a 4 byte value (or 16 bytes for ipv6 I guess).
- The `dhcp-option` directive now parses `vendor:...` which is used to classify options in response to certain vendor classes. This is currently not implemented in the unikernel.
- The unikernel configuration massaging code now uses an intermediate record instead of a n-tuple (where n is large). A notable change is that multiple log-server options are now allowed and are concatenated. I think this is fine to do.

After beginning writing this PR text I found it would probably have been more worthwhile to implement [Vendor-Identifying Vendor Options](https://www.rfc-editor.org/rfc/rfc3925.html) as it seems to allow for more key-value style vendor specific options instead of just one blob of vendor specific data (though I only skimmed the RFC).