### PR TITLE
Support tags to some degree

### DIFF
--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -548,9 +548,10 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
               acc.tagged_dhcp_options
           in
           gather { acc with tagged_dhcp_options } r
-      | `Dhcp_option ({ tags = _a::_b::_ } as dhcp_option) :: _ ->
-                Error
-            (Fmt.str "Don't know how to handle dhcp-option with multiple tags %a"
+      | `Dhcp_option ({ tags = _a :: _b :: _ } as dhcp_option) :: _ ->
+          Error
+            (Fmt.str
+               "Don't know how to handle dhcp-option with multiple tags %a"
                Dnsvizor.Config_parser.pp_dhcp_option dhcp_option)
       | `Dhcp_option ({ option = _ } as dhcp_option) :: _ ->
           Error


### PR DESCRIPTION
The tags can only be set in dhcp-host, and only matched in dhcp-option. In addition dhcp-option can match at most one tag at a time. For example, `dhcp-option=tag:foo,tag:bar,tag:baz,option:log-server,127.0.0.1` only matches when the client matches **all** tags. I found out this was the semantics after writing the implementation so I modified it to only allow one tag (otherwise I was matching on **any** tag).

It's a bit unclear to me if we need to do some filtering of "default" options if there are more specific options. I don't think that is the case, but I'm unclear on the dnsmasq/DHCP semantics.

I  tested this in a coupe of combinations of tagged clients and differently tagged options and in those cases it worked as I had expected.