### PR TITLE
support dhcp-authoritative flag

### DIFF
--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -133,6 +133,23 @@ module K = struct
       in
       Arg.(value & opt (some Config_parser.domain_c) None doc)
 
+    let no_hosts =
+      let doc =
+        Arg.info
+          ~doc:
+            "Don't 'read' the (synthesized) /etc/hosts (contains only --name \
+             argument)"
+          [ "no-hosts" ]
+      in
+      Arg.(value & flag doc)
+
+    let dnssec =
+      let doc =
+        Arg.info ~doc:"Validate DNS replies and cache DNSSEC data."
+          ~docs:s_dnsmasq [ "dnssec" ]
+      in
+      Arg.(value & flag doc)
+
     (* various ignored DNSmasq configuration options *)
     let interface =
       let doc =
@@ -172,21 +189,13 @@ module K = struct
       in
       Arg.(value & flag doc)
 
-    (* Further configuration options, not ignored *)
-    let no_hosts =
+    let dhcp_authoritative =
       let doc =
-        Arg.info
+        Arg.info ~docs:Manpage.s_none
           ~doc:
-            "Don't 'read' the (synthesized) /etc/hosts (contains only --name \
-             argument)"
-          [ "no-hosts" ]
-      in
-      Arg.(value & flag doc)
-
-    let dnssec =
-      let doc =
-        Arg.info ~doc:"Validate DNS replies and cache DNSSEC data."
-          ~docs:s_dnsmasq [ "dnssec" ]
+            "Should be set when DNSvizor is definitively the only DHCP server \
+             on a network. Assumed by charrua, our DHCP server implementation."
+          [ "dhcp-authoritative" ]
       in
       Arg.(value & flag doc)
   end
@@ -201,13 +210,14 @@ module K = struct
     and+ dhcp_host = dhcp_host
     and+ dhcp_option = dhcp_option
     and+ domain = domain
+    and+ no_hosts = no_hosts
+    and+ dnssec = dnssec
     and+ _ = interface
     and+ _ = except_interface
     and+ _ = listen_address
     and+ _ = no_dhcp_interface
     and+ _ = bind_interfaces
-    and+ no_hosts = no_hosts
-    and+ dnssec = dnssec in
+    and+ _ = dhcp_authoritative in
     Option.map (fun x -> `Dhcp_range x) dhcp_range
     @? Option.map (fun x -> `Domain x) domain
     @? (if no_hosts then Some `No_hosts else None)

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -615,6 +615,8 @@ let parse_file data =
            ignore_directive "listen-address";
            ignore_directive "no-dhcp-interface";
            ignore_flag "bind-interfaces";
+           ignore_flag "dhcp-authoritative"
+           (* charrua assumes to be the authoritative anyways *);
            ( string "#" *> commit *> ignore_line "#" <?> "comment" >>| fun _ ->
              `Ignored );
          ]

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -428,6 +428,31 @@ let small_carpie_conf =
          ());
   ]
 
+let netbeez_conf =
+  [
+    `Dhcp_range
+      {
+        start_addr = Ipaddr.V4.of_string_exn "172.31.0.220";
+        end_addr = Some (Ipaddr.V4.of_string_exn "172.31.0.250");
+        mode = None;
+        netmask = Some (Ipaddr.V4.of_string_exn "255.255.255.0");
+        broadcast = None;
+        lease_time = Some (12 * 60 * 60);
+      };
+    `Dhcp_option
+      {
+        tags = [];
+        vendor = None;
+        option = Dhcp_wire.Routers [ Ipaddr.V4.of_string_exn "172.31.0.1" ];
+      };
+    `Dhcp_option
+      {
+        tags = [];
+        vendor = None;
+        option = Dhcp_wire.Dns_servers [ Ipaddr.V4.of_string_exn "1.1.1.1" ];
+      };
+  ]
+
 let config_file_tests =
   [
     ("First example", `Quick, test_configuration [] "simple.conf");
@@ -440,6 +465,9 @@ let config_file_tests =
     ( "smaller carpie.net configuration",
       `Quick,
       test_configuration small_carpie_conf "smaller-carpie.conf" );
+    ( "netbeez configuration",
+      `Quick,
+      test_configuration netbeez_conf "netbeez.conf" );
   ]
 
 let tests =

--- a/test/sample-configuration-files/netbeez.conf
+++ b/test/sample-configuration-files/netbeez.conf
@@ -1,0 +1,4 @@
+dhcp-range=172.31.0.220,172.31.0.250,255.255.255.0,12h
+dhcp-option=option:router,172.31.0.1
+dhcp-option=option:dns-server,1.1.1.1
+dhcp-authoritative


### PR DESCRIPTION
we ignore it since charrua anyways assumes to be the one DHCP server on the network. we may at some point investigate whether we can shortcut anything in charrua based on the fact that we're the only DHCP server:

From the dnsmasq manpage:
```
              Should be set when dnsmasq is definitely the only DHCP server on
              a network.  For DHCPv4, it changes the behaviour from strict RFC
              compliance so that DHCP requests on unknown leases from unknown
              hosts are not ignored. This allows new hosts to get a lease
              without a tedious timeout under all circumstances. It also
              allows dnsmasq to rebuild its lease database without each client
              needing to reacquire a lease, if the database is lost. For
              DHCPv6 it sets the priority in replies to 255 (the maximum)
              instead of 0 (the minimum).
```

this pushes the example configuration from #18 to the testsuite \o/