### PR TITLE
Domain needed

### DIFF
--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -560,7 +560,7 @@ type config_item =
   | `Dhcp_option of dhcp_option
   | `No_hosts
   | `Dnssec
-  | `Domain_needed]
+  | `Domain_needed ]
 
 type config = [ config_item | `Ignored ] list
 

--- a/src/config_parser.ml
+++ b/src/config_parser.ml
@@ -559,7 +559,8 @@ type config_item =
   | `Domain of domain
   | `Dhcp_option of dhcp_option
   | `No_hosts
-  | `Dnssec ]
+  | `Dnssec
+  | `Domain_needed]
 
 type config = [ config_item | `Ignored ] list
 
@@ -575,6 +576,7 @@ let pp_config_item mode ppf item =
       Fmt.pf ppf "dhcp-option=%a" pp_dhcp_option dhcp_option
   | `No_hosts -> Fmt.string ppf "no-hosts"
   | `Dnssec -> Fmt.string ppf "dnssec"
+  | `Domain_needed -> Fmt.string ppf "domain-needed"
 
 let pp_config mode ppf config =
   let sep = match mode with `File -> Fmt.any "\n" | `Arg -> Fmt.any " " in
@@ -610,6 +612,7 @@ let parse_file data =
            >>| fun domain -> `Domain domain );
            ( directive_prefix "dhcp-option" *> dhcp_option conf_end_of_directive
            >>| fun dhcp_option -> `Dhcp_option dhcp_option );
+           (flag "domain-needed" >>| fun _ -> `Domain_needed);
            ignore_directive "interface";
            ignore_directive "except-interface";
            ignore_directive "listen-address";

--- a/src/config_parser.mli
+++ b/src/config_parser.mli
@@ -61,6 +61,7 @@ type config =
   | `Dhcp_option of dhcp_option
   | `No_hosts
   | `Dnssec
+  | `Domain_needed
   | `Ignored ]
   list
 

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -468,6 +468,9 @@ let config_file_tests =
     ( "netbeez configuration",
       `Quick,
       test_configuration netbeez_conf "netbeez.conf" );
+    ( "domain-needed configuration",
+      `Quick,
+      test_configuration [ `Domain_needed ] "domain-needed.conf" );
   ]
 
 let tests =

--- a/test/sample-configuration-files/domain-needed.conf
+++ b/test/sample-configuration-files/domain-needed.conf
@@ -1,0 +1,1 @@
+domain-needed

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -150,12 +150,13 @@ module K = struct
       in
       Arg.(value & flag doc)
 
-    let domain_needed=
+    let domain_needed =
       let doc =
-        Arg.info ~doc:"Never forward A or AAAA queries for plain names, \
-                       without dots or domain parts, to upstream nameservers. \
-                       If the name is not known from /etc/hosts or DHCP then a \
-                       \"not found\" answer is returned."
+        Arg.info
+          ~doc:
+            "Never forward A or AAAA queries for plain names, without dots or \
+             domain parts, to upstream nameservers. If the name is not known \
+             from /etc/hosts or DHCP then a \"not found\" answer is returned."
           ~docs:s_dnsmasq [ "domain-needed" ]
       in
       Arg.(value & flag doc)
@@ -1808,8 +1809,8 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
               let module Dhcp_dns = Dhcp_dns (Stub) in
               Stub.H.connect_device stack >>= fun happy_eyeballs ->
               try
-                Stub.create ~require_domain ?cache_size:(K.dns_cache ()) ~nameservers:[ ns ]
-                  primary_t ~happy_eyeballs stack
+                Stub.create ~require_domain ?cache_size:(K.dns_cache ())
+                  ~nameservers:[ ns ] primary_t ~happy_eyeballs stack
                 >>= fun resolver ->
                 net.lease_acquired <- Dhcp_dns.dhcp_lease_cb tcp resolver domain;
                 let t = { net; mac; configuration } in


### PR DESCRIPTION
This implements --domain-needed on top of https://github.com/mirage/ocaml-dns/pull/406 (commit https://github.com/mirage/ocaml-dns/pull/406/commits/6103561756f028f72db6c2c42f259e687783229e)

If we are a recursive resolver the argument is ignored (dnsmasq is not a recursive resolver so there's no precedence there).

```
; <<>> DiG 9.20.15-1~deb13u1-Debian <<>> @172.23.53.53 foo
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 19587
;; flags: qr rd ad; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
;; WARNING: recursion requested but not available

;; QUESTION SECTION:
;foo.				IN	A

;; Query time: 3 msec
;; SERVER: 172.23.53.53#53(172.23.53.53) (UDP)
;; WHEN: Fri Nov 28 15:05:17 CET 2025
;; MSG SIZE  rcvd: 21

```

Looking at the output I notice here we have `ADDITIONAL: 0` instead of `ADDITIONAL: 1` 