### PR TITLE
Add missing dependency metrics-lwt

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -11,6 +11,7 @@ let dnsvizor =
     [
       package "logs";
       package ~min:"0.5.0" "metrics";
+      package ~min:"0.5.0" "metrics-lwt";
       package "dns";
       package "dns-client";
       package "dns-client-mirage";


### PR DESCRIPTION
previous error:

mirage-dnsvizor-unix-dev> File "unikernel.ml", line 1788, characters 4-29:
mirage-dnsvizor-unix-dev> 1788 |     Metrics_lwt.init_periodic (fun () -> Mirage_sleep.ns (Duration.of_sec 10));
mirage-dnsvizor-unix-dev>            ^^^^^^^^^^^^^^^^^^^^^^^^^
mirage-dnsvizor-unix-dev> Error: Unbound module Metrics_lwt

