### PR TITLE
Vendor identifying + certificates

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -6,7 +6,7 @@ open Mirage
 let assets = crunch "assets"
 
 let dnsvizor =
-  let local_libs = [ "dnsvizor" ] in
+  let local_libs = [ "dnsvizor"; "dnsvizor-csr" ] in
   let packages =
     [
       package "logs";
@@ -23,7 +23,7 @@ let dnsvizor =
       package ~min:"10.2.1" ~sublibs:[ "mirage" ] "dns-stub";
       package "dns-tsig";
       package "dns-server";
-      package "dns";
+      package "dns-certify";
       package "paf" ~sublibs:[ "mirage"; "alpn" ];
       package ~min:"3.0.0" "ethernet";
       package ~min:"3.0.0" ~sublibs:[ "mirage" ] "arp";

--- a/config.ml
+++ b/config.ml
@@ -30,7 +30,7 @@ let dnsvizor =
       package ~min:"7.0.0"
         ~sublibs:[ "ipv4"; "tcp"; "udp"; "icmpv4"; "stack-direct"; "ipv6" ]
         "tcpip";
-      package ~min:"3.0.0" "charrua";
+      package ~min:"3.1.0" "charrua";
       package "charrua-server";
       package ~min:"4.5.0" ~sublibs:[ "network" ] "mirage-runtime";
       package "tyxml";

--- a/csr/dnsvizor_csr.ml
+++ b/csr/dnsvizor_csr.ml
@@ -12,10 +12,10 @@ let encode csr =
 let decode s =
   let ( let* ) = Result.bind in
   let* len =
-    if String.length s < prefix_len then Error (`Msg "Truncated")
+    if String.length s < prefix_len then Error `Not_csr
     else if String.starts_with ~prefix s then
       Ok (String.get_uint16_be s prefix_len)
-    else Error (`Msg "Not a CSR")
+    else Error `Not_csr
   in
   let off = prefix_len + 2 in
   let* data =

--- a/csr/dnsvizor_csr.ml
+++ b/csr/dnsvizor_csr.ml
@@ -1,0 +1,26 @@
+let prefix = "csr\000"
+let prefix_len = String.length prefix
+
+let encode csr =
+  let der = X509.Signing_request.encode_der csr in
+  let b = Bytes.create (String.length prefix + 2 + String.length der) in
+  Bytes.blit_string prefix 0 b 0 prefix_len;
+  Bytes.set_uint16_be b prefix_len (String.length der);
+  Bytes.blit_string der 0 b (prefix_len + 2) (String.length der);
+  Bytes.unsafe_to_string b
+
+let decode s =
+  let ( let* ) = Result.bind in
+  let* len =
+    if String.length s < prefix_len then Error (`Msg "Truncated")
+    else if String.starts_with ~prefix s then
+      Ok (String.get_uint16_be s prefix_len)
+    else Error (`Msg "Not a CSR")
+  in
+  let off = prefix_len + 2 in
+  let* data =
+    (* TODO(reynir): we don't do anything with slack at the end; revise *)
+    if String.length s < off + len then Error (`Msg "Truncated")
+    else Ok (String.sub s off len)
+  in
+  X509.Signing_request.decode_der data

--- a/csr/dnsvizor_csr.ml
+++ b/csr/dnsvizor_csr.ml
@@ -25,22 +25,18 @@ let decode s =
   in
   X509.Signing_request.decode_der data
 
-
-
 let encode_src (ip, domain) =
   (match ip with
-   | Ipaddr.V4 ip ->
-     "4" ^ Ipaddr.V4.to_octets ip
-   | Ipaddr.V6 ip ->
-     "6" ^ Ipaddr.V6.to_octets ip) ^
-  Domain_name.to_string domain
+    | Ipaddr.V4 ip -> "4" ^ Ipaddr.V4.to_octets ip
+    | Ipaddr.V6 ip -> "6" ^ Ipaddr.V6.to_octets ip)
+  ^ Domain_name.to_string domain
 
 let decode_src s =
   let ( let* ) = Result.bind in
   let* v =
-    if String.length s < 1 then
-      Error (`Msg "Truncated")
-    else match String.get s 0 with
+    if String.length s < 1 then Error (`Msg "Truncated")
+    else
+      match String.get s 0 with
       | '4' -> Ok `V4
       | '6' -> Ok `V6
       | _illegal -> Error (`Msg "Bad ip type")
@@ -48,17 +44,17 @@ let decode_src s =
   let* ip, off =
     match v with
     | `V4 ->
-      if String.length s < 1 + 4 then
-        Error (`Msg "Truncated")
-      else
-        let* ipv4 = Ipaddr.V4.of_octets ~off:1 s in
-        Ok (Ipaddr.V4 ipv4, 1 + 4)
+        if String.length s < 1 + 4 then Error (`Msg "Truncated")
+        else
+          let* ipv4 = Ipaddr.V4.of_octets ~off:1 s in
+          Ok (Ipaddr.V4 ipv4, 1 + 4)
     | `V6 ->
-      if String.length s < 1 + 16 then
-        Error (`Msg "Truncated")
-      else
-        let* ipv6 = Ipaddr.V6.of_octets ~off:1 s in
-        Ok (Ipaddr.V6 ipv6, 1 + 16)
+        if String.length s < 1 + 16 then Error (`Msg "Truncated")
+        else
+          let* ipv6 = Ipaddr.V6.of_octets ~off:1 s in
+          Ok (Ipaddr.V6 ipv6, 1 + 16)
   in
-  let* domain = Domain_name.of_string (String.sub s off (String.length s - off)) in
+  let* domain =
+    Domain_name.of_string (String.sub s off (String.length s - off))
+  in
   Ok (ip, domain)

--- a/csr/dnsvizor_csr.mli
+++ b/csr/dnsvizor_csr.mli
@@ -1,2 +1,5 @@
 val encode : X509.Signing_request.t -> string
 val decode : string -> (X509.Signing_request.t, [> `Msg of string ]) result
+
+val encode_src : Ipaddr.t * _ Domain_name.t -> string
+val decode_src : string -> (Ipaddr.t * [ `raw ] Domain_name.t, [> `Msg of string ]) result

--- a/csr/dnsvizor_csr.mli
+++ b/csr/dnsvizor_csr.mli
@@ -1,6 +1,6 @@
 val encode : X509.Signing_request.t -> string
 (** [encode csr] is [csr] encoded as a string suitable to put as a
-    Vendor-Identifyin Vendor Class data under the Mirage Private Enterprise
+    Vendor-Identifying Vendor Class data under the Mirage Private Enterprise
     Number (49836). *)
 
 val decode :

--- a/csr/dnsvizor_csr.mli
+++ b/csr/dnsvizor_csr.mli
@@ -1,5 +1,9 @@
 val encode : X509.Signing_request.t -> string
-val decode : string -> (X509.Signing_request.t, [> `Not_csr | `Msg of string ]) result
+
+val decode :
+  string -> (X509.Signing_request.t, [> `Not_csr | `Msg of string ]) result
 
 val encode_src : Ipaddr.t * _ Domain_name.t -> string
-val decode_src : string -> (Ipaddr.t * [ `raw ] Domain_name.t, [> `Msg of string ]) result
+
+val decode_src :
+  string -> (Ipaddr.t * [ `raw ] Domain_name.t, [> `Msg of string ]) result

--- a/csr/dnsvizor_csr.mli
+++ b/csr/dnsvizor_csr.mli
@@ -1,9 +1,28 @@
+(** [encode csr] is [csr] encoded as a string suitable to put as a
+    Vendor-Identifyin Vendor Class data under the Mirage Private Enterprise
+    Number (49836). *)
 val encode : X509.Signing_request.t -> string
 
+(** [decode s] is either
+    - [Ok csr] where [csr] is a certificate signing request,
+    - [Error `Not_csr] if [s] does not start with the magic prefix, or
+    - [Error (`Msg _)] if decoding [s] failed with an error.
+
+    See  {!encode} for the context. *)
 val decode :
   string -> (X509.Signing_request.t, [> `Not_csr | `Msg of string ]) result
 
+(** [encode_src (ipaddr, domain)] is the string encoding of [(ipaddr, domain)].
+    Used in DHCP Vendor-Identifying Vendor-Specific Option for the Mirage
+    Private Enterprise Number (49836) suboption 1, and is used for
+    communicating what DNS server to query the domain to find the TLSA records
+    with the signed certificate. *)
 val encode_src : Ipaddr.t * _ Domain_name.t -> string
 
+(** [decode_src s] is either:
+    - [Ok (ipaddr, domain)], or
+    - [Error _] if the encoding is somehow invalid.
+
+    See {!encode_src} for the context. *)
 val decode_src :
   string -> (Ipaddr.t * [ `raw ] Domain_name.t, [> `Msg of string ]) result

--- a/csr/dnsvizor_csr.mli
+++ b/csr/dnsvizor_csr.mli
@@ -1,5 +1,5 @@
 val encode : X509.Signing_request.t -> string
-val decode : string -> (X509.Signing_request.t, [> `Msg of string ]) result
+val decode : string -> (X509.Signing_request.t, [> `Not_csr | `Msg of string ]) result
 
 val encode_src : Ipaddr.t * _ Domain_name.t -> string
 val decode_src : string -> (Ipaddr.t * [ `raw ] Domain_name.t, [> `Msg of string ]) result

--- a/csr/dnsvizor_csr.mli
+++ b/csr/dnsvizor_csr.mli
@@ -1,0 +1,2 @@
+val encode : X509.Signing_request.t -> string
+val decode : string -> (X509.Signing_request.t, [> `Msg of string ]) result

--- a/csr/dnsvizor_csr.mli
+++ b/csr/dnsvizor_csr.mli
@@ -1,28 +1,28 @@
+val encode : X509.Signing_request.t -> string
 (** [encode csr] is [csr] encoded as a string suitable to put as a
     Vendor-Identifyin Vendor Class data under the Mirage Private Enterprise
     Number (49836). *)
-val encode : X509.Signing_request.t -> string
 
+val decode :
+  string -> (X509.Signing_request.t, [> `Not_csr | `Msg of string ]) result
 (** [decode s] is either
     - [Ok csr] where [csr] is a certificate signing request,
     - [Error `Not_csr] if [s] does not start with the magic prefix, or
     - [Error (`Msg _)] if decoding [s] failed with an error.
 
-    See  {!encode} for the context. *)
-val decode :
-  string -> (X509.Signing_request.t, [> `Not_csr | `Msg of string ]) result
+    See {!encode} for the context. *)
 
+val encode_src : Ipaddr.t * _ Domain_name.t -> string
 (** [encode_src (ipaddr, domain)] is the string encoding of [(ipaddr, domain)].
     Used in DHCP Vendor-Identifying Vendor-Specific Option for the Mirage
-    Private Enterprise Number (49836) suboption 1, and is used for
-    communicating what DNS server to query the domain to find the TLSA records
-    with the signed certificate. *)
-val encode_src : Ipaddr.t * _ Domain_name.t -> string
+    Private Enterprise Number (49836) suboption 1, and is used for communicating
+    what DNS server to query the domain to find the TLSA records with the signed
+    certificate. *)
 
+val decode_src :
+  string -> (Ipaddr.t * [ `raw ] Domain_name.t, [> `Msg of string ]) result
 (** [decode_src s] is either:
     - [Ok (ipaddr, domain)], or
     - [Error _] if the encoding is somehow invalid.
 
     See {!encode_src} for the context. *)
-val decode_src :
-  string -> (Ipaddr.t * [ `raw ] Domain_name.t, [> `Msg of string ]) result

--- a/csr/dune
+++ b/csr/dune
@@ -1,0 +1,4 @@
+(library
+ (name dnsvizor_csr)
+ (public_name dnsvizor-csr)
+ (libraries x509))

--- a/csr/dune
+++ b/csr/dune
@@ -1,4 +1,4 @@
 (library
  (name dnsvizor_csr)
  (public_name dnsvizor-csr)
- (libraries x509))
+ (libraries x509 ipaddr))

--- a/dnsvizor-csr.opam
+++ b/dnsvizor-csr.opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis:     "Library implementing DNSvizor CSR things"
+name:         "dnsvizor-csr"
+homepage:     "https://github.com/robur-coop/dnsvizor"
+dev-repo:     "git+https://github.com/robur-coop/dnsvizor.git"
+bug-reports:  "https://github.com/robur-coop/dnsvizor/issues"
+doc:          "https://github.com/robur-coop/dnsvizor/doc"
+author:       ["Robur <team@robur.coop>"]
+maintainer:   ["Robur <team@robur.coop>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst" ] {dev}
+  ["dune" "build"   "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.14.0"}
+  "odoc" {with-doc}
+  "x509"
+]

--- a/dnsvizor-csr.opam
+++ b/dnsvizor-csr.opam
@@ -19,5 +19,6 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.14.0"}
   "odoc" {with-doc}
-  "x509"
+  "x509" {>= "1.0.0"}
+  "ipaddr"
 ]

--- a/src/config_parser.mli
+++ b/src/config_parser.mli
@@ -69,3 +69,30 @@ val pp_config : [ `File | `Arg ] -> config Fmt.t
 val parse_file : string -> (config, [> `Msg of string ]) result
 val arg_end_of_directive : unit Angstrom.t
 val parse_one : 'a Angstrom.t -> string -> ('a, [> `Msg of string ]) result
+
+(** {2 Non-dnsmasq options} *)
+
+type mirage_metrics_sink = { tags : string list; sink : string }
+
+val pp_mirage_metrics_sink : mirage_metrics_sink Fmt.t
+val mirage_metrics_sink : unit Angstrom.t -> mirage_metrics_sink Angstrom.t
+val mirage_metrics_sink_docv : string
+val mirage_metrics_sink_c : mirage_metrics_sink Cmdliner.Arg.conv
+
+type mirage_vivso = {
+  tags : string list;
+  subopt_code : int;
+  subopt_data : string;
+}
+
+val pp_mirage_vivso : mirage_vivso Fmt.t
+val mirage_vivso : unit Angstrom.t -> mirage_vivso Angstrom.t
+val mirage_vivso_docv : string
+val mirage_vivso_c : mirage_vivso Cmdliner.Arg.conv
+
+type mirage_certify = string list (* list of tags *)
+
+val pp_mirage_certify : mirage_certify Fmt.t
+val mirage_certify : unit Angstrom.t -> mirage_certify Angstrom.t
+val mirage_certify_docv : string
+val mirage_certify_c : mirage_certify Cmdliner.Arg.conv

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -289,7 +289,7 @@ let ok_domain3 () =
     check (result domain_t msg_t) "Domain is good" (Ok expected)
       (parse_one_arg domain input))
 
-let eq_dhcp_option a b =
+let eq_dhcp_option (a : dhcp_option) (b : dhcp_option) =
   List.equal String.equal a.tags b.tags
   && (match (a.vendor, b.vendor) with
     | None, None -> true

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,7 @@
 (test
  (name config_tests)
  (modules config_tests)
+ (package dnsvizor)
  (libraries alcotest fmt logs.fmt dnsvizor)
  (deps
   (source_tree sample-configuration-files)))

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -333,7 +333,10 @@ module K = struct
 
     let mirage_metrics_sink =
       let doc =
-        let doc = "Mirage metrics sink. The format is: [mac],sink." in
+        let doc =
+          "Mirage metrics sink. The format is: [mac,]sink. If a mac is \
+           supplied the option only applies to that host."
+        in
         Arg.info ~doc [ "mirage-metrics-sink" ]
       in
       let metrics_conv =
@@ -347,7 +350,8 @@ module K = struct
         let doc =
           "Mirage Vendor-Identifying vendor-specific option. This uses the \
            MirageOS private enterprise number 49836. The format is: \
-           subopt-code,[mac],subopt-data."
+           subopt-code,[mac,]subopt-data. If a mac is supplied the option only \
+           applies to that host."
         in
         Arg.info ~doc [ "mirage-vivso" ]
       in

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1795,7 +1795,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
                     let flow = Dns_mirage.of_flow flow in
                     query_certificate_or_csr flow hostname key_name key_domain
                       key csr
-                    >|= Result.map Option.some
+                    >|= Result.map (fun domain -> Some (ip, domain))
               else (
                 Logs.warn (fun m ->
                     m "Requested a DNS update with %a, but key domain is %a"
@@ -2094,7 +2094,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
                         (* Replace the mirage-certify option with the domain name where to
                find the certificate. *)
                         let options' =
-                          let domain = Option.map Domain_name.to_string domain in
+                          let domain = Option.map Dnsvizor_csr.encode_src domain in
                           assert (domain <> Some "");
                           List.map
                             (function

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -43,6 +43,43 @@ module CA = struct
     >>= fun certificate -> Ok (certificate, pk)
 end
 
+(* This takes a list of host configurations and merge the ones for the same
+   client judged by its mac. *)
+let merge_hosts hosts =
+  List.sort (fun h h' -> Macaddr.compare h.Dhcp_server.Config.hw_addr h'.Dhcp_server.Config.hw_addr) hosts
+  |> List.fold_left (fun (acc, cur) h ->
+      match cur with
+      | None -> (acc, Some h)
+      | Some cur ->
+        if Macaddr.compare cur.Dhcp_server.Config.hw_addr h.Dhcp_server.Config.hw_addr <> 0 then
+          (cur :: acc, Some h)
+        else
+          let hw_addr = cur.hw_addr in
+          let fixed_addr =
+            match cur.fixed_addr, h.fixed_addr with
+            | Some addr, None | None, Some addr -> Some addr
+            | Some addr, Some addr' ->
+              Logs.warn (fun m -> m "Duplicate IPv4 addresses for %a: %a, %a using the former"
+                            Macaddr.pp hw_addr Ipaddr.V4.pp addr Ipaddr.V4.pp addr');
+              Some addr
+            | None, None -> None
+          in
+          let hostname =
+            match cur.hostname, h.hostname with
+            | "", hostname | hostname, "" -> hostname
+            | hostname, hostname' ->
+              Logs.debug (fun m -> m "Duplicate hostname for %a: %S, %S using the former"
+                             Macaddr.pp hw_addr hostname hostname');
+              hostname
+          in
+          let options = h.options @ cur.options in
+          let cur = { Dhcp_server.Config.hw_addr; fixed_addr; options; hostname } in
+          (acc, Some cur))
+    ([], None)
+  |> function
+  | acc, None -> acc
+  | acc, Some cur -> cur :: acc
+
 module K = struct
   open Cmdliner
   open Dnsvizor
@@ -250,6 +287,102 @@ module K = struct
     @? (if bogus_priv then Some `Bogus_priv else None)
     @? List.map (fun x -> `Dhcp_option x) dhcp_option
     @ List.map (fun x -> `Dhcp_host x) dhcp_host
+
+  module Dhcp_ext = struct
+    let mac_conv =
+      let parse = Macaddr.of_string
+      and print = Macaddr.pp in
+      Arg.conv (parse, print)
+
+    let opt_pair ?docv_opt ?docv_req opt req =
+      let docv_opt = Option.value docv_opt ~default:(Arg.conv_docv opt)
+      and docv_req = Option.value docv_req ~default:(Arg.conv_docv req) in
+      let parse s =
+        match String.index_opt s ',' with
+        | None ->
+          Result.map (fun v -> None, v) (Arg.conv_parser req s)
+        | Some i ->
+          let s_opt = String.sub s 0 i
+          and s_req = String.sub s (succ i) (String.length s - i - 1) in
+          match Arg.conv_parser opt s_opt, Arg.conv_parser req s_req with
+          | Ok opt, Ok req ->
+            Ok (Some opt, req)
+          | Error e, _ | _, Error e -> Error e
+      and print ppf v =
+        match v with
+        | None, v -> Arg.conv_printer req ppf v
+        | Some o, v ->
+          Fmt.pf ppf "%a,%a" (Arg.conv_printer opt) o (Arg.conv_printer req) v
+      in
+      let docv = Fmt.str "[%s,]%s" docv_opt docv_req in
+      Arg.conv ~docv (parse, print)
+
+    let mirage_metrics_sink =
+      let doc =
+        Arg.info ~doc:"Mirage metrics sink"
+          [ "mirage-metrics-sink" ]
+      in
+      let metrics_conv =
+        (* TODO: more precise converter than [Arg.string] *)
+        opt_pair ~docv_opt:"MAC" ~docv_req:"SINK" mac_conv Arg.string
+      in
+      Arg.(value & opt_all metrics_conv [] doc)
+
+    let mirage_vivso =
+      let doc =
+        Arg.info ~doc:"Mirage Vendor-Identifying vendor-specific option."
+          [ "mirage-vivso" ]
+      in
+      let subopt_code =
+        let parse s =
+          match Arg.(conv_parser int) s with
+          | Ok n ->
+            if n < 0  || n > 255 then
+              Error (`Msg "Suboption code must be between 0-255")
+            else Ok n
+          | Error _ as e -> e
+        and print = Arg.(conv_printer int) in
+        Arg.conv ~docv:"SUBOPT-CODE" (parse, print)
+      in
+      let vivso_conv =
+        Arg.pair subopt_code
+          (opt_pair mac_conv Arg.string
+             ~docv_opt:"MAC" ~docv_req:"DATA")
+      in
+      Arg.(value & opt_all vivso_conv [] doc)
+  end
+
+  let mirage_dhcp =
+    let open Cmdliner.Term.Syntax in
+    let+ metrics_sinks = Dhcp_ext.mirage_metrics_sink
+    and+ vivso = Dhcp_ext.mirage_vivso in
+    let metrics_sink_default, metrics_sinks =
+      let option sink =
+        (* 49836 is MirageOS private enterprise number *)
+        Dhcp_wire.Vi_vendor_info [ 49836l, [ 0, sink ]]
+      in
+      (* It seems [Dhcp_server.Config.hostname] isn't actually used so we can
+         put anything there. *)
+      List.partition_map (function
+          | None, sink -> Left (option sink)
+          | Some hw_addr, sink ->
+          Right { Dhcp_server.Config.hw_addr; options = [ option sink ]; fixed_addr = None; hostname = "" })
+        metrics_sinks
+    in
+    let default_vivso, vivso =
+      let option code data =
+        Dhcp_wire.Vi_vendor_info [ 49836l, [code, data] ]
+      in
+      List.partition_map (function
+          | (subopt_code, (None, opt)) ->
+            Left (option subopt_code opt)
+          | (subopt_code, (Some hw_addr, opt)) ->
+            Right { Dhcp_server.Config.hw_addr; options = [ option subopt_code opt ]; fixed_addr = None; hostname = "" })
+        vivso
+    in
+    metrics_sink_default @ default_vivso, merge_hosts (metrics_sinks @ vivso)
+
+  let mirage_dhcp = Mirage_runtime.register_arg mirage_dhcp
 
   let qname_minimisation =
     let doc =
@@ -681,6 +814,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
       Option.to_list
         (Option.map (fun x -> Dhcp_wire.Routers [ x ]) (K.ipv4_gateway ()))
     and dns_server = [ Dhcp_wire.Dns_servers [ ipv4_address ] ] in
+    let mirage_default_options, mirage_hosts = K.mirage_dhcp () in
     let options =
       (if
          List.exists
@@ -700,6 +834,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
              (fun domain ->
                Dhcp_wire.Domain_name (Domain_name.to_string domain))
              domain)
+      @ mirage_default_options
     in
     let hosts =
       List.concat_map
@@ -713,6 +848,9 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
                     | None -> acc
                     | Some additional_options ->
                         (* XXX: do we need to deduplicate?! *)
+                        (* The [hostname] field doesn't actually do anything -
+                           so we add a Hostname dhcp option *)
+                        Dhcp_wire.Hostname hostname ::
                         additional_options @ acc)
                   options sets
               in
@@ -720,6 +858,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
             macs)
         dhcp_hosts
     in
+    let hosts = merge_hosts (mirage_hosts @ hosts) in
     let max_lease_time = Option.map (fun lt -> lt * 2) default_lease_time in
     let dhcp_config =
       Dhcp_server.Config.make ?hostname:None ?default_lease_time ?max_lease_time

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -2009,20 +2009,22 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
         List.filter_map
           (function
             | Dhcp_wire.Vi_vendor_info vivso ->
-              let vivso =
-                List.filter_map
-                  (function
-                    | 49836l(*mirage_pen*), subopts ->
-                      let subopts =
-                        List.filter (function 1, _ -> false | _ -> true) subopts
-                      in
-                      if subopts = [] then
-                        None
-                      else Some (mirage_pen, subopts)
-                    | x -> Some x)
-                  vivso
-              in
-              if vivso = [] then None else Some (Dhcp_wire.Vi_vendor_info vivso)
+                let vivso =
+                  List.filter_map
+                    (function
+                      | 49836l (*mirage_pen*), subopts ->
+                          let subopts =
+                            List.filter
+                              (function 1, _ -> false | _ -> true)
+                              subopts
+                          in
+                          if subopts = [] then None
+                          else Some (mirage_pen, subopts)
+                      | x -> Some x)
+                    vivso
+                in
+                if vivso = [] then None
+                else Some (Dhcp_wire.Vi_vendor_info vivso)
             | opt -> Some opt)
           options
       in
@@ -2083,7 +2085,8 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
       | Some hostname, new_options ->
           if List.mem pkt.Dhcp_wire.chaddr (K.mirage_certify ()) then
             match
-              Dhcp_wire.collect_vi_vendor_class options |> List.assoc_opt mirage_pen
+              Dhcp_wire.collect_vi_vendor_class options
+              |> List.assoc_opt mirage_pen
             with
             | None ->
                 (* As the client is not in the list we don't need to strip *)
@@ -2122,7 +2125,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
                                   let vivso =
                                     List.map
                                       (function
-                                        | 49836l(*mirage_pen*), subopts ->
+                                        | 49836l (*mirage_pen*), subopts ->
                                             ( mirage_pen,
                                               List.filter_map
                                                 (function

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1,5 +1,8 @@
 open Lwt.Infix
 
+(* 49836 is MirageOS private enterprise number *)
+let mirage_pen = 49836l
+
 module CA = struct
   let prefix =
     X509.Distinguished_name.
@@ -382,8 +385,7 @@ module K = struct
     and+ vivso = Dhcp_ext.mirage_vivso in
     let metrics_sink_default, metrics_sinks =
       let option sink =
-        (* 49836 is MirageOS private enterprise number *)
-        Dhcp_wire.Vi_vendor_info [ (49836l, [ (0, sink) ]) ]
+        Dhcp_wire.Vi_vendor_info [ (mirage_pen, [ (0, sink) ]) ]
       in
       (* It seems [Dhcp_server.Config.hostname] isn't actually used so we can
          put anything there. *)
@@ -402,7 +404,7 @@ module K = struct
     in
     let default_vivso, vivso =
       let option code data =
-        Dhcp_wire.Vi_vendor_info [ (49836l, [ (code, data) ]) ]
+        Dhcp_wire.Vi_vendor_info [ (mirage_pen, [ (code, data) ]) ]
       in
       List.partition_map
         (function
@@ -856,7 +858,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
     let mirage_default_options, mirage_hosts = K.mirage_dhcp () in
     let certify_hosts =
       (* The empty string is a dummy value that will be replaced in dhcp_lease_cb *)
-      let option = Dhcp_wire.Vi_vendor_info [ (49836l, [ (1, "") ]) ] in
+      let option = Dhcp_wire.Vi_vendor_info [ (mirage_pen, [ (1, "") ]) ] in
       List.map
         (fun hw_addr ->
           {
@@ -2063,8 +2065,8 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
                     let vivso =
                       List.map
                         (function
-                          | 49836l, subopts ->
-                              ( 49836l,
+                          | 49836l (*mirage_pen*), subopts ->
+                              ( mirage_pen,
                                 List.filter
                                   (function 1, _ -> false | _ -> true)
                                   subopts )
@@ -2079,7 +2081,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
       | Some hostname, new_options ->
           if List.mem pkt.Dhcp_wire.chaddr (K.mirage_certify ()) then
             match
-              Dhcp_wire.collect_vi_vendor_class options |> List.assoc_opt 49836l
+              Dhcp_wire.collect_vi_vendor_class options |> List.assoc_opt mirage_pen
             with
             | None ->
                 (* As the client is not in the list we don't need to strip *)
@@ -2118,8 +2120,8 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
                                   let vivso =
                                     List.map
                                       (function
-                                        | 49836l, subopts ->
-                                            ( 49836l,
+                                        | 49836l(*mirage_pen*), subopts ->
+                                            ( mirage_pen,
                                               List.filter_map
                                                 (function
                                                   | 1, _ ->
@@ -2145,8 +2147,8 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
                       let vivso =
                         List.map
                           (function
-                            | 49836l, subopts ->
-                                ( 49836l,
+                            | 49836l(*mirage_pen*), subopts ->
+                                ( mirage_pen,
                                   List.filter
                                     (function 1, _ -> false | _ -> true)
                                     subopts )

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -294,8 +294,8 @@ module K = struct
     let mirage_certify =
       let doc =
         let doc =
-          "Mirage dns-certify. Allow this host to acquire a certificate using \
-           ACME DNS-01 challenge. The format is: macaddr."
+          "Mirage dns-certify. Allow hosts matching the given tags to acquire \
+           a certificate using  ACME DNS-01 challenge. The format is: macaddr."
         in
         Arg.info ~doc ~docs ~docv:Config_parser.mirage_certify_docv
           [ "mirage-certify" ]

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -854,6 +854,7 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
     and dns_server = [ Dhcp_wire.Dns_servers [ ipv4_address ] ] in
     let mirage_default_options, mirage_hosts = K.mirage_dhcp () in
     let certify_hosts =
+      (* The empty string is a dummy value that will be replaced in dhcp_lease_cb *)
       let option = Dhcp_wire.Vi_vendor_info [ (49836l, [ (1, "") ]) ] in
       List.map
         (fun hw_addr ->
@@ -2076,7 +2077,9 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
               Dhcp_wire.collect_vi_vendor_class options
               |> List.assoc_opt 49836l
             with
-            | None -> Lwt.return (Ok (options' @ new_options))
+            | None ->
+              (* As the client is not in the list we don't need to strip *)
+              Lwt.return (Ok (options' @ new_options))
             | Some data -> (
                 (* TODO: how do we future proof this? *)
                 match Dnsvizor_csr.decode data with


### PR DESCRIPTION
This adds a few new options for vendor-identifying vendor-specific options.

The sub option 1 under the MirageOS PEN is used for certificates. The client sends in the vendor-identifying vendor class option the CSR, dnsvizor submits it in DNS and sends to the client where it can find the certificate.

The client is responsible for querying DNS for the certificate. This is done partly because DHCP clients tend to be impatient and partly because it's difficult to fit long certificate chains in a DHCP message. To avoid caching DNS servers the client is given the ip address of the DNS primary server to query for the certificates. This is not ideal if the primary is a hidden primary.

This also adds a library `dnsvizor-csr` for encoding and decoding the CSR and the ip address × domain name pair. We may reconsider the format for the CSR especially considering https://github.com/mirage/charrua/issues/146.