### PR TITLE
Recognize mollymawk clones and extract the correct hostnames

### DIFF
--- a/unikernel.ml
+++ b/unikernel.ml
@@ -2115,6 +2115,21 @@ module Main (N : Mirage_net.S) (ASSETS : Mirage_kv.RO) = struct
            options
        with
       | Some (Hostname name) ->
+          (* mollymawk can create clones. if the original unikernel is 
+          called blog, then the clones will be named blog-clone-<int> where int >= 1
+        and so when these clones request for an ip, we should register the ip with the 
+        same hostname as the original unikernel.*)
+          let name =
+            match String.split_on_char '-' name with
+            | hostname :: "clone" :: _ ->
+                Logs.info (fun m ->
+                    m
+                      "The client %s is a mollymawk clone. Setting hostname to \
+                       %s"
+                      name hostname);
+                hostname
+            | _ -> name
+          in
           let trie = Resolver.primary_data resolver in
           let trie =
             insert_dns_records trie name domain


### PR DESCRIPTION
This PR enables DNSvizor to be able to recognize a `dhcp_lease` request from a cloned unikernel in mollymawk. 
In mollymawk we follow the naming convension as such:
- if the primary (original) unikernel is called `hello`, then the first clone will be named `hello-clone-1` and so on and so forth.

The problem is, if we give the clone a `--name=original_unikernel_name` argument, then DNSvizor registers the ip correctly under the domain of the original unikernel, however, everything else which relies on unikernels having unique names, such as metrics and syslog, have corrupted/colliding data.

This PR solves this by letting the clone keep it's unique name, but at the level of the `dhcp_request`, extract the name of the original unikernel and assign the IP correctly. 

See the logs below:

- first, the original unikernel requests for an IP:

```
Message type DHCP REQUEST, Request IP 10.0.0.148, Server identifier 10.0.0.6, Hostname blog
[2026-07-04T06:15:24-00:00] 2026-07-04T06:15:24-00:00: [INFO] [application] recording blog.service to 10.0.0.148
```

- then when a clone is spawned, it also request for an IP:

```
Message type DHCP REQUEST, Request IP 10.0.0.174, Server identifier 10.0.0.6, Hostname blog-clone-1
[2026-07-04T06:16:01-00:00] 2026-07-04T06:16:01-00:00: [INFO] [application] The client blog-clone-1 is a mollymawk clone. Setting hostname to blog
[2026-07-04T06:16:01-00:00] 2026-07-04T06:16:01-00:00: [INFO] [application] recording blog.service to 10.0.0.174
```

We can verify with `dig` that `blog-clone-1.service` doesn't exist and both IP's are registered only to `blog.service`

```shell
ndahi@ndahi:~/work/robur/dnsvizor$ dig blog.service @10.0.0.6

; <<>> DiG 9.20.11-1ubuntu2.4-Ubuntu <<>> blog.service @10.0.0.6
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 58973
;; flags: qr aa; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;blog.service.			IN	A

;; ANSWER SECTION:
blog.service.		3600	IN	A	10.0.0.148
blog.service.		3600	IN	A	10.0.0.174

;; Query time: 0 msec
;; SERVER: 10.0.0.6#53(10.0.0.6) (UDP)
;; WHEN: Sat Jul 04 07:27:53 WAT 2026
;; MSG SIZE  rcvd: 62
```

```sh
ndahi@ndahi:~/work/robur/dnsvizor$ dig blog-clone-1.service @10.0.0.6

; <<>> DiG 9.20.11-1ubuntu2.4-Ubuntu <<>> blog-clone-1.service @10.0.0.6
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 46157
;; flags: qr aa; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 0

;; QUESTION SECTION:
;blog-clone-1.service.		IN	A

;; AUTHORITY SECTION:
service.		3600	IN	SOA	service. hostmaster. 0 86400 7200 3600000 3600

;; Query time: 1 msec
;; SERVER: 10.0.0.6#53(10.0.0.6) (UDP)
;; WHEN: Sat Jul 04 07:27:58 WAT 2026
;; MSG SIZE  rcvd: 84

ndahi@ndahi:~/work/robur/dnsvizor$ 
```